### PR TITLE
Remove force flag from docker tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   java:
     version: openjdk7
   pre:
-    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.3
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
     - sudo wget -O /usr/local/bin/docker-compose 'https://github.com/docker/compose/releases/download/1.6.2/docker-compose-Linux-x86_64'
     - sudo chmod 0755 /usr/local/bin/docker-compose
   services:
@@ -24,4 +24,3 @@ deployment:
     commands:
       - ./gradlew -i bintrayUpload
       - ./gradlew -i -Dgradle.publish.key=$GRADLE_KEY -Dgradle.publish.secret=$GRADLE_SECRET publishPlugins
-

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -103,7 +103,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                         group = 'Docker'
                         description = "Tags Docker image with tag '${tagName}'"
                         workingDir dockerDir
-                        commandLine 'docker', 'tag', '--force=true', ext.name, computeName(ext.name, tagName)
+                        commandLine 'docker', 'tag', ext.name, computeName(ext.name, tagName)
                         dependsOn exec
                     })
                     tag.dependsOn subTask

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -157,7 +157,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
+        execCond("docker rmi -f ${id}") || true
     }
 
     def 'Publishes "docker" dependencies via "docker" component'() {


### PR DESCRIPTION
`-f` is deprecated in Docker 1.10.0 and will be removed in 1.12.0. I'm happy to sit on this PR if it's too early.
