### PR TITLE
#45: Add support for docker build args

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,8 @@ automatically include outputs of task dependencies in the Docker build context.
 - `dependsOn` (optional) an argument list of tasks that docker builds must depend on;
   defaults to the empty set
 - `files` (optional) an argument list of files to be included in the docker build context
+- 'buildArgs' (optional) an argument map of string to string which will set --build-arg;
+  arguments to the docker build command
 
 To build a docker container, run the `docker` task. To push that container to a
 docker repository, run the `dockerPush` task.
@@ -57,6 +59,7 @@ Configuration specifying all parameters:
         dockerfile 'Dockerfile'
         dependsOn tasks.distTar
         files 'file1.txt', 'file2.txt'
+        buildArgs([BUILD_VERSION: 'version'])
     }
 
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ automatically include outputs of task dependencies in the Docker build context.
 - `dependsOn` (optional) an argument list of tasks that docker builds must depend on;
   defaults to the empty set
 - `files` (optional) an argument list of files to be included in the docker build context
-- 'buildArgs' (optional) an argument map of string to string which will set --build-arg;
+- `buildArgs` (optional) an argument map of string to string which will set --build-arg;
   arguments to the docker build command
 
 To build a docker container, run the `docker` task. To push that container to a

--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,8 @@ automatically include outputs of task dependencies in the Docker build context.
 - `dependsOn` (optional) an argument list of tasks that docker builds must depend on;
   defaults to the empty set
 - `files` (optional) an argument list of files to be included in the docker build context
-- `buildArgs` (optional) an argument map of string to string which will set --build-arg;
-  arguments to the docker build command
+- `buildArgs` (optional) an argument map of string to string which will set --build-arg
+  arguments to the docker build command; defaults to empty, which results in no --build-arg parameters
 
 To build a docker container, run the `docker` task. To push that container to a
 docker repository, run the `dockerPush` task.

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Task
 
 import com.google.common.base.Preconditions
 import com.google.common.base.Strings
+import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
 
 class DockerExtension {
@@ -32,6 +33,7 @@ class DockerExtension {
     private Set<Task> dependencies = ImmutableSet.of()
     private Set<String> files = ImmutableSet.of()
     private Set<String> tags = ImmutableSet.of()
+    private Map<String, String> buildArgs = ImmutableMap.of()
 
     private File resolvedDockerfile = null
     private File resolvedDockerComposeTemplate = null
@@ -117,5 +119,13 @@ class DockerExtension {
         }
 
         resolvedFiles = builder.build()
+    }
+
+    public Map<String, String> getBuildArgs() {
+        return buildArgs
+    }
+
+    public void buildArgs(Map<String, String> buildArgs) {
+        this.buildArgs = ImmutableMap.copyOf(buildArgs);
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -85,9 +85,16 @@ class PalantirDockerPlugin implements Plugin<Project> {
                 into dockerDir
             }
 
+            List<String> buildCommandLine = ['docker', 'build']
+            if (! ext.buildArgs.isEmpty()) {
+                for (Map.Entry<String, String> buildArg : ext.buildArgs.entrySet()) {
+                    buildCommandLine.addAll('--build-arg', "${buildArg.getKey()}=${buildArg.getValue()}")
+                }
+            }
+            buildCommandLine.addAll(['-t', ext.name, '.'])
             exec.with {
                 workingDir dockerDir
-                commandLine 'docker', 'build', '-t', ext.name, '.'
+                commandLine buildCommandLine
                 dependsOn ext.getDependencies()
             }
 

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -179,7 +179,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m)HELLO WORLD/
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is STOPPED./
+        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
     }
 
 


### PR DESCRIPTION
I added a new buildArgs parameter to the docker configuration and a new test.  buildArgs lets you control the --build-arg parameter to docker build, as requested in #45.

I am more than happy to add more tests, squash the branch down into a single commit, make the commit messages fit a certain style, etc.

I also fixed a test for Docker Run that has likely been failing for a while, but is only enabled on local Linux environments.
