### PR TITLE
Fix a couple of breaking unit tests

### DIFF
--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -16,7 +16,6 @@
 package com.palantir.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.TaskOutcome
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -16,8 +16,7 @@
 package com.palantir.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
-
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.gradle.testkit.runner.TaskOutcome
 
 class DockerRunPluginTests extends AbstractPluginTest {
 
@@ -48,20 +47,20 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult offline = with('dockerRunStatus', 'dockerRemoveContainer').build()
 
         then:
-        buildResult.task(':docker').outcome == SUCCESS
-        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
 
-        buildResult.task(':dockerRun').outcome == SUCCESS
+        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         // CircleCI build nodes print a WARNING
         buildResult.output =~ /(?m):dockerRun(WARNING:.*\n)?\n[A-Za-z0-9]+/
 
-        buildResult.task(':dockerRunStatus').outcome == SUCCESS
+        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is RUNNING./
 
-        buildResult.task(':dockerStop').outcome == SUCCESS
+        buildResult.task(':dockerStop').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerStop\nfoo/
 
-        offline.task(':dockerRunStatus').outcome == SUCCESS
+        offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         offline.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
 
         execCond('docker rmi -f foo-image')
@@ -87,19 +86,19 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult offline = with('dockerRunStatus', 'dockerRemoveContainer').build()
 
         then:
-        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
 
-        buildResult.task(':dockerRun').outcome == SUCCESS
+        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         // CircleCI build nodes print a WARNING
         buildResult.output =~ /(?m):dockerRun(WARNING:.*\n)?\n[A-Za-z0-9]+/
 
-        buildResult.task(':dockerRunStatus').outcome == SUCCESS
+        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is RUNNING./
 
-        buildResult.task(':dockerStop').outcome == SUCCESS
+        buildResult.task(':dockerStop').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerStop\nbar/
 
-        offline.task(':dockerRunStatus').outcome == SUCCESS
+        offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         offline.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is STOPPED./
     }
 
@@ -123,11 +122,11 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
 
         then:
-        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
 
-        buildResult.task(':dockerRun').outcome == SUCCESS
+        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
 
-        buildResult.task(':dockerRunStatus').outcome == SUCCESS
+        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar-nodaemonize' is STOPPED./
     }
 
@@ -175,9 +174,9 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('docker', 'dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
 
         then:
-        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
 
-        buildResult.task(':dockerRun').outcome == SUCCESS
+        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m)HELLO WORLD/
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -18,6 +18,8 @@ package com.palantir.gradle.docker
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
 class DockerRunPluginTests extends AbstractPluginTest {
 
     def 'can run, status, and stop a container made by the docker plugin' () {
@@ -47,20 +49,20 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult offline = with('dockerRunStatus', 'dockerRemoveContainer').build()
 
         then:
-        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
 
-        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRun').outcome == SUCCESS
         // CircleCI build nodes print a WARNING
         buildResult.output =~ /(?m):dockerRun(WARNING:.*\n)?\n[A-Za-z0-9]+/
 
-        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRunStatus').outcome == SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is RUNNING./
 
-        buildResult.task(':dockerStop').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerStop').outcome == SUCCESS
         buildResult.output =~ /(?m):dockerStop\nfoo/
 
-        offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+        offline.task(':dockerRunStatus').outcome == SUCCESS
         offline.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
 
         execCond('docker rmi -f foo-image')
@@ -86,19 +88,19 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult offline = with('dockerRunStatus', 'dockerRemoveContainer').build()
 
         then:
-        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
 
-        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRun').outcome == SUCCESS
         // CircleCI build nodes print a WARNING
         buildResult.output =~ /(?m):dockerRun(WARNING:.*\n)?\n[A-Za-z0-9]+/
 
-        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRunStatus').outcome == SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is RUNNING./
 
-        buildResult.task(':dockerStop').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerStop').outcome == SUCCESS
         buildResult.output =~ /(?m):dockerStop\nbar/
 
-        offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+        offline.task(':dockerRunStatus').outcome == SUCCESS
         offline.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is STOPPED./
     }
 
@@ -122,11 +124,11 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
 
         then:
-        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
 
-        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRun').outcome == SUCCESS
 
-        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRunStatus').outcome == SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar-nodaemonize' is STOPPED./
     }
 
@@ -174,9 +176,9 @@ class DockerRunPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('docker', 'dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
 
         then:
-        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRemoveContainer').outcome == SUCCESS
 
-        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerRun').outcome == SUCCESS
         buildResult.output =~ /(?m)HELLO WORLD/
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -314,7 +314,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
             docker {
                 name '${id}'
-                tags 'mytag', 'another'
+                tags 'latest', 'another'
             }
         """.stripIndent()
 

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -21,8 +21,6 @@ import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvide
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
-import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
-
 class PalantirDockerPluginTests extends AbstractPluginTest {
 
     def 'fail when missing docker configuration'() {
@@ -98,8 +96,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('docker').build()
 
         then:
-        buildResult.task(':dockerPrepare').outcome == SUCCESS
-        buildResult.task(':docker').outcome == SUCCESS
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n" as String
         execCond("docker rmi -f ${id}")
     }
@@ -126,8 +124,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('docker').build()
 
         then:
-        buildResult.task(':dockerPrepare').outcome == SUCCESS
-        buildResult.task(':docker').outcome == SUCCESS
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n" as String
         execCond("docker rmi -f ${id}")
     }
@@ -156,8 +154,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('docker').build()
 
         then:
-        buildResult.task(':dockerPrepare').outcome == SUCCESS
-        buildResult.task(':docker').outcome == SUCCESS
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n" as String
         execCond("docker rmi -f ${id}") || true
     }
@@ -204,7 +202,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         when:
         BuildResult buildResult = with('publishToMavenLocal').build()
         then:
-        buildResult.task(':publishToMavenLocal').outcome == SUCCESS
+        buildResult.task(':publishToMavenLocal').outcome == TaskOutcome.SUCCESS
         def publishFolder = new DefaultLocalMavenRepositoryLocator(
             new DefaultMavenSettingsProvider(new DefaultMavenFileLocations())).localMavenRepository.toPath()
             .resolve("testgroup")
@@ -245,7 +243,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         when:
         BuildResult buildResult = with('tasks').build()
         then:
-        buildResult.task(':tasks').outcome == SUCCESS
+        buildResult.task(':tasks').outcome == TaskOutcome.SUCCESS
     }
 
     def 'no tag task when no tags defined'() {
@@ -324,9 +322,9 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('dockerTag').build()
 
         then:
-        buildResult.task(':dockerPrepare').outcome == SUCCESS
-        buildResult.task(':docker').outcome == SUCCESS
-        buildResult.task(':dockerTag').outcome == SUCCESS
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':dockerTag').outcome == TaskOutcome.SUCCESS
         exec("docker inspect --format '{{.Author}}' ${id}") == imageId
         exec("docker inspect --format '{{.Author}}' ${id}:latest") == imageId
         exec("docker inspect --format '{{.Author}}' ${id}:another") == imageId


### PR DESCRIPTION
I had a couple of consistently failing unit tests, which this PR fixes.

My environment is:

Ubuntu 15.10
Docker version 1.9.1, build a34a1d5

The fixes I made were:
- Test starts docker image 'foo' but expects 'bar' to stop.
- Tagging test hits a conflict when trying to tag 'latest'. I think 'latest' is a default tag, so I've made the test less likely to conflict by changing the built tag names.

Please let me know if these fixes are valid as I intend to develop a new feature and I'll be using my fork as a base.
