### PR TITLE
Run 'docker version' in dockerSetup.

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerSetupTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerSetupTask.groovy
@@ -16,10 +16,8 @@
 package com.palantir.gradle.docker
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.os.OperatingSystem
 
 class DockerSetupTask extends DefaultTask {
 
@@ -30,32 +28,14 @@ class DockerSetupTask extends DefaultTask {
 
     @Override
     public String getDescription() {
-        return 'Verify that Docker-related environment variables are set'
+        return 'Verify that Docker daemon is running.'
     }
 
     @TaskAction
     public void action() {
-        if (!OperatingSystem.current().isLinux()) {
-            def dockerTlsVerify = System.getenv('DOCKER_TLS_VERIFY')
-            def dockerHost = System.getenv('DOCKER_HOST')
-            def dockerCertPath = System.getenv('DOCKER_CERT_PATH')
-            def dockerMachineName = System.getenv('DOCKER_MACHINE_NAME')
-            def error = ''
-            if (!System.env.DOCKER_TLS_VERIFY) {
-                error += 'DOCKER_TLS_VERIFY not set.\n'
-            }
-            if (!System.env.DOCKER_HOST) {
-                error += 'DOCKER_HOST not set.\n'
-            }
-            if (!System.env.DOCKER_CERT_PATH) {
-                error += 'DOCKER_CERT_PATH not set.\n'
-            }
-            if (!System.env.DOCKER_MACHINE_NAME) {
-                error += 'DOCKER_MACHINE_NAME not set.\n'
-            }
-            if (error != '') {
-                throw new GradleException(error += 'Please make sure your Docker VM is running.')
-            }
+        project.exec {
+            executable "docker"
+            args "version"
         }
     }
 


### PR DESCRIPTION
- Should print something like the following if docker is down:

```
:dockerSetup
    Client:
    Cannot connect to the Docker daemon. Is the docker daemon running on this host?
     Version:      1.12.0-rc2
     API version:  1.24
     Go version:   go1.6.2
     Git commit:   906eacd
     Built:        Fri Jun 17 20:35:33 2016
     OS/Arch:      darwin/amd64
     Experimental: true
    :dockerSetup FAILED
```

Should fix #37. Looking for ideas on how to test this; I tried sudo service stop docker, but I'm not sure it is actually possible to stop the docker daemon on CircleCI?
