### PR TITLE
Add 'pull' parameter to docker plugin

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -34,6 +34,7 @@ class DockerExtension {
     private Set<String> files = ImmutableSet.of()
     private Set<String> tags = ImmutableSet.of()
     private Map<String, String> buildArgs = ImmutableMap.of()
+    private boolean pull = false
 
     private File resolvedDockerfile = null
     private File resolvedDockerComposeTemplate = null
@@ -75,7 +76,7 @@ class DockerExtension {
     }
 
     public void files(String... args) {
-        this.files = ImmutableSet.copyOf(args);
+        this.files = ImmutableSet.copyOf(args)
     }
 
     public Set<String> getTags() {
@@ -83,7 +84,7 @@ class DockerExtension {
     }
 
     public void tags(String... args) {
-        this.tags = ImmutableSet.copyOf(args);
+        this.tags = ImmutableSet.copyOf(args)
     }
 
     public File getResolvedDockerfile() {
@@ -126,6 +127,14 @@ class DockerExtension {
     }
 
     public void buildArgs(Map<String, String> buildArgs) {
-        this.buildArgs = ImmutableMap.copyOf(buildArgs);
+        this.buildArgs = ImmutableMap.copyOf(buildArgs)
+    }
+
+    public boolean getPull() {
+        return pull
+    }
+
+    public void pull(boolean pull) {
+        this.pull = pull
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -89,6 +89,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     buildCommandLine.addAll('--build-arg', "${buildArg.getKey()}=${buildArg.getValue()}")
                 }
             }
+            if (ext.pull) {
+                buildCommandLine.add '--pull'
+            }
             buildCommandLine.addAll(['-t', ext.name, '.'])
             exec.with {
                 workingDir dockerDir


### PR DESCRIPTION
This adds a new `pull` parameter to the `docker` plugin, which defines whether Docker should attempt to pull a newer version of the base image before starting a build.

Oh, and I also added syntax highlighting to the Readme, because it looks great on GitHub :relieved:
