### PR TITLE
possible fix for https://github.com/palantir/gradle-docker/issues/58

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ automatically include outputs of task dependencies in the Docker build context.
   `${projectDir}/Dockerfile`
 - `dependsOn` (optional) an argument list of tasks that docker builds must depend on;
   defaults to the empty set
-- `files` (optional) an argument list of files to be included in the docker build context
+- `files` (optional) an argument list of files to be included in the docker build context; if this parameter is omitted, all files in `${projectDir}` are included
 - `buildArgs` (optional) an argument map of string to string which will set --build-arg
   arguments to the docker build command; defaults to empty, which results in no --build-arg parameters
 - `pull` (optional) a boolean argument which defines whether Docker should attempt to pull

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -79,7 +79,23 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     }
                 }
                 from ext.dependencies*.outputs
-                from ext.resolvedFiles
+                if (!ext.resolvedFiles.isEmpty()) {
+                    // provide compatibility with optional 'files' parameter:
+                    from ext.resolvedFiles
+                } else {
+                    // default: copy all files that are NOT excluded by '.dockerignore'
+                    // NOTE:
+                    //  the patterns from .dockeringore DO NOT EXACTLY match gradles exclude patterns
+                    //  ... but for many cases it provides a reasonable solution :)
+                    // TODO: translate golangs filepath.Match pattern to gradles exclude pattern
+                    File dockerignore = new File("${project.projectDir}/.dockerignore")
+                    from(project.projectDir) {
+                        exclude "${project.buildDir.name}"
+                        if (dockerignore.exists()) {
+                            exclude dockerignore.text.split()
+                        }
+                    }
+                }
                 into dockerDir
             }
 

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -79,7 +79,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     }
                 }
                 from ext.dependencies*.outputs
-                if (!ext.resolvedFiles.isEmpty()) {
+                if (ext.resolvedFiles) {
                     // provide compatibility with optional 'files' parameter:
                     from ext.resolvedFiles
                 } else {

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -83,24 +83,16 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     // provide compatibility with optional 'files' parameter:
                     from ext.resolvedFiles
                 } else {
-                    // default: copy all files that are NOT excluded by '.dockerignore'
-                    // NOTE:
-                    //  the patterns from .dockeringore DO NOT EXACTLY match gradles exclude patterns
-                    //  ... but for many cases it provides a reasonable solution :)
-                    // TODO: translate golangs filepath.Match pattern to gradles exclude pattern
-                    File dockerignore = new File("${project.projectDir}/.dockerignore")
+                    // default: copy all files excluding the project buildDir
                     from(project.projectDir) {
                         exclude "${project.buildDir.name}"
-                        if (dockerignore.exists()) {
-                            exclude dockerignore.text.split()
-                        }
                     }
                 }
                 into dockerDir
             }
 
             List<String> buildCommandLine = ['docker', 'build']
-            if (! ext.buildArgs.isEmpty()) {
+            if (!ext.buildArgs.isEmpty()) {
                 for (Map.Entry<String, String> buildArg : ext.buildArgs.entrySet()) {
                     buildCommandLine.addAll('--build-arg', "${buildArg.getKey()}=${buildArg.getValue()}")
                 }


### PR DESCRIPTION
Hi.

Please consider this possible (quick) solution.

Note: the solution tries to respect the patterns found in .dockerignore but does so in a very simple manner. An improvemnt would be to actually translate the golang filepath patterns used in .dockerignore to gradles "ANT like" exclude pattern.

Regards,
-Stefan
