### PR TITLE
Create the correct name for images

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -145,11 +145,22 @@ class PalantirDockerPlugin implements Plugin<Project> {
         }
     }
 
-    private String computeName(String name, String tag) {
-        return name.replaceAll(":.*", "") + ":" + tag
+    private static String computeName(String name, String tag) {
+        int lastColon = name.lastIndexOf(':')
+        int lastSlash = name.lastIndexOf('/')
+
+        int endIndex;
+
+        // image_name -> this should remain
+        // host:port/image_name -> this should remain.
+        // host:port/image_name:v1 -> v1 should be replaced
+        if (lastColon > lastSlash) endIndex = lastColon
+        else endIndex = name.length()
+
+        return name.substring(0, endIndex) + ":" + tag
     }
 
-    private String ucfirst(String str) {
+    private static String ucfirst(String str) {
         StringBuffer sb = new StringBuffer(str);
         sb.replace(0, 1, str.substring(0, 1).toUpperCase());
         return sb.toString();

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenFileLocations
 import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvider
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Unroll
 
 class PalantirDockerPluginTests extends AbstractPluginTest {
 
@@ -417,5 +418,18 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         execCond("docker rmi -f ${id}") || true
     }
 
+    def 'check if compute name replaces the name correctly'() {
+        expect:
+        PalantirDockerPlugin.computeName(name, tag) == result
+
+        where:
+        name                |  tag         | result
+        "v1"                | "latest"     | "v1:latest"
+        "v1:1"              | "latest"     | "v1:latest"
+        "host/v1"           | "latest"     | "host/v1:latest"
+        "host/v1:1"         | "latest"     | "host/v1:latest"
+        "host:port/v1"      | "latest"     | "host:port/v1:latest"
+        "host:port/v1:1"    | "latest"     | "host:port/v1:latest"
+    }
 }
 


### PR DESCRIPTION
Just replacing the first colon til the end of the image name is not the correct way to replace a tag.
The name itself has to be checked further and than the correct paths can be split.

Just see the new test-method "check if compute name replaces the name correctly" what the possible values are.
