### PR TITLE
Add possibility to copy and preserve a folder. Also allow to copy the…

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -99,7 +99,7 @@ class DockerExtension {
         return resolvedDockerComposeFile
     }
 
-    public Set<String> getResolvedFiles() {
+    public Set<File> getResolvedFiles() {
         return resolvedFiles
     }
 
@@ -115,7 +115,8 @@ class DockerExtension {
         ImmutableSet.Builder<File> builder = ImmutableSet.builder()
         for (String file : files) {
             def resFile = project.file(file)
-            Preconditions.checkArgument(resFile.exists(), "file '%s' does not exist.", file)
+            def nonWildcardFile = isWildcardDirectory(resFile) ? resFile.getParentFile() : resFile
+            Preconditions.checkArgument(nonWildcardFile.exists(), "file '%s' does not exist.", file)
             builder.add(resFile)
         }
 
@@ -136,5 +137,9 @@ class DockerExtension {
 
     public void pull(boolean pull) {
         this.pull = pull
+    }
+
+    public static boolean isWildcardDirectory(File folder) {
+        folder.getName().equals("*")
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -87,7 +87,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     }
                 }
 
-                ([] + ext.dependencies*.outputs*.getFiles()*.getFiles().flatten() + ext.resolvedFiles).forEach { File file ->
+                ([] + ext.dependencies*.outputs*.getFiles()*.getFiles().flatten() + ext.resolvedFiles).each { File file ->
                     def wildcardDirectory = isWildcardDirectory(file)
 
                     /**

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -29,6 +29,8 @@ import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.bundling.Zip
 
+import static com.palantir.gradle.docker.DockerExtension.isWildcardDirectory
+
 class PalantirDockerPlugin implements Plugin<Project> {
 
     private static final Logger log = Logging.getLogger(PalantirDockerPlugin.class)
@@ -84,11 +86,27 @@ class PalantirDockerPlugin implements Plugin<Project> {
                         fileName.replace(ext.resolvedDockerfile.getName(), 'Dockerfile')
                     }
                 }
-                from ext.dependencies*.outputs
-                if (ext.resolvedFiles) {
-                    // provide compatibility with optional 'files' parameter:
-                    from ext.resolvedFiles
-                } else {
+
+                ([] + ext.dependencies*.outputs*.getFiles()*.getFiles().flatten() + ext.resolvedFiles).forEach { File file ->
+                    def wildcardDirectory = isWildcardDirectory(file)
+
+                    /**
+                     * Supports copying of directories (preserving the directory itself) and also just copying the
+                     * content of a directory by using a '*' wildcard (e.g. /tmp/*)
+                     */
+                    if (wildcardDirectory) {
+                        file = file.getParentFile()
+                    }
+
+                    from (file) {
+                        // Preserve a copied folder if no wildcard is used at the very end
+                        if (file.isDirectory() && !wildcardDirectory) {
+                            into(file.getName())
+                        }
+                    }
+                }
+
+                if (!ext.resolvedFiles) {
                     // default: copy all files excluding the project buildDir
                     from(project.projectDir) {
                         exclude "${project.buildDir.name}"

--- a/src/test/groovy/com/palantir/gradle/docker/AbstractPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/AbstractPluginTest.groovy
@@ -27,6 +27,7 @@ class AbstractPluginTest extends Specification {
     TemporaryFolder temporaryFolder = new TemporaryFolder()
 
     File projectDir
+    File dockerDir
     File buildFile
     List<File> pluginClasspath
 
@@ -55,6 +56,7 @@ class AbstractPluginTest extends Specification {
 
     def setup() {
         projectDir = temporaryFolder.root
+        dockerDir = new File(projectDir, "build/docker")
         buildFile = temporaryFolder.newFile('build.gradle')
 
         def pluginClasspathResource = getClass().classLoader.findResource("plugin-classpath.txt")


### PR DESCRIPTION
… content of a folder by using a '/*' at the very end

I had the problem, that gradle-tasks had output-files, which point to directories. 
But the gradle-copy task with `from ... into ...` not preservs that folder (https://docs.gradle.org/current/userguide/working_with_files.html#sec:copying_files) and just copies the content of it.

This PR allows:

```
task outputTask {
    outputs.files('some_folder', 'some_other_folder/*')
}
docker {
...
    dependsOn outputTask
    files 'my_folder', 'my_other_folder/*'
}
```

This will copy `my_folder`and `some_folder` as they are and the content of `my_other_folder` and `some_other_folder`.

So everything is still possible, what was possible before.

_Breaking Change:_
If someone relies that this plugin only copies the content of a folder, this must be re-configured by adding a `/*`. 
