### PR TITLE
Fix #86: Exclude "buildDir/docker" instead of "buildDir" and fix infinite loop when explicitly including everything

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,23 +42,34 @@ if (System.env.CIRCLE_TEST_REPORTS) {
 }
 
 group 'com.palantir.gradle.docker'
-version gitVersion()
+version '0.9.3'
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource
     classifier 'sources'
 }
-  
+
 publishing {
     publications {
-        bintray(MavenPublication) {
+        mavenJava(MavenPublication) {
             from components.java
-            artifact(sourceJar)
-            artifact(publishPluginJavaDocsJar)
         }
     }
 }
-  
+
+publishing {
+    repositories {
+        mavenLocal()
+        maven {
+            url "http://israproductions.com:8081/repository/maven-releases"
+            credentials {
+                username "admin"
+                password "admin123"
+            }
+        }
+    }
+}
+
 bintray {
     user = System.env.BINTRAY_USER
     key = System.env.BINTRAY_KEY

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -85,14 +85,17 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     }
                 }
                 from ext.dependencies*.outputs
+	            def files
                 if (ext.resolvedFiles) {
                     // provide compatibility with optional 'files' parameter:
-                    from ext.resolvedFiles
+	                files = ext.resolvedFiles
                 } else {
-                    // default: copy all files excluding the project buildDir
-                    from(project.projectDir) {
-                        exclude "${project.buildDir.name}"
-                    }
+	                // default: copy all files
+	                files = project.projectDir
+                }
+	            from(files) {
+		            // excluding project.buildDir/docker
+		            exclude "${project.buildDir.name}/docker"
                 }
                 into dockerDir
             }
@@ -157,9 +160,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
         int lastColon = name.lastIndexOf(':')
         int lastSlash = name.lastIndexOf('/')
 
-        int endIndex;
+	    int endIndex
 
-        // image_name -> this should remain
+	    // image_name -> this should remain
         // host:port/image_name -> this should remain.
         // host:port/image_name:v1 -> v1 should be replaced
         if (lastColon > lastSlash) endIndex = lastColon
@@ -169,9 +172,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
     }
 
     private static String ucfirst(String str) {
-        StringBuffer sb = new StringBuffer(str);
-        sb.replace(0, 1, str.substring(0, 1).toUpperCase());
-        return sb.toString();
+	    StringBuffer sb = new StringBuffer(str)
+	    sb.replace(0, 1, str.substring(0, 1).toUpperCase())
+	    return sb.toString()
     }
 
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -85,17 +85,14 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     }
                 }
                 from ext.dependencies*.outputs
-	            def files
                 if (ext.resolvedFiles) {
                     // provide compatibility with optional 'files' parameter:
-	                files = ext.resolvedFiles
+                    from ext.resolvedFiles
                 } else {
-	                // default: copy all files
-	                files = project.projectDir
-                }
-	            from(files) {
-		            // excluding project.buildDir/docker
-		            exclude "${project.buildDir.name}/docker"
+                    // default: copy all files excluding the project buildDir
+                    from(project.projectDir) {
+                        exclude "${project.buildDir.name}"
+                    }
                 }
                 into dockerDir
             }
@@ -160,9 +157,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
         int lastColon = name.lastIndexOf(':')
         int lastSlash = name.lastIndexOf('/')
 
-	    int endIndex
+        int endIndex;
 
-	    // image_name -> this should remain
+        // image_name -> this should remain
         // host:port/image_name -> this should remain.
         // host:port/image_name:v1 -> v1 should be replaced
         if (lastColon > lastSlash) endIndex = lastColon
@@ -172,9 +169,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
     }
 
     private static String ucfirst(String str) {
-	    StringBuffer sb = new StringBuffer(str)
-	    sb.replace(0, 1, str.substring(0, 1).toUpperCase())
-	    return sb.toString()
+        StringBuffer sb = new StringBuffer(str);
+        sb.replace(0, 1, str.substring(0, 1).toUpperCase());
+        return sb.toString();
     }
 
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -85,14 +85,17 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     }
                 }
                 from ext.dependencies*.outputs
+                def files
                 if (ext.resolvedFiles) {
                     // provide compatibility with optional 'files' parameter:
-                    from ext.resolvedFiles
+                    files = ext.resolvedFiles
                 } else {
-                    // default: copy all files excluding the project buildDir
-                    from(project.projectDir) {
-                        exclude "${project.buildDir.name}"
-                    }
+                    // default: copy all files
+                    files = project.projectDir
+                }
+                from(files) {
+                    // excluding project.buildDir/docker
+                    exclude "${project.buildDir.name}/docker"
                 }
                 into dockerDir
             }

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -420,7 +420,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
     def 'outputs from default distribution locations are added to the docker context'() {
         given:
         String id = 'id11'
-        File distributions = temporaryFolder.newFolder('build', 'distributions');
+        File distributions = new File(projectDir, 'build/distributions');
+        distributions.mkdirs();
         new File(distributions, 'dist.txt').createNewFile();
 
         file('Dockerfile') << """
@@ -448,7 +449,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
     def 'explicitly adding everything does not crash due to recursive overflow'() {
         given:
         String id = 'id12'
-        File distributions = temporaryFolder.newFolder('build', 'distributions');
+        File distributions = new File(projectDir, 'build/distributions');
+        distributions.mkdirs();
         new File(distributions, 'dist.txt').createNewFile();
 
         file('Dockerfile') << """

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -423,7 +423,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         File distributions = temporaryFolder.newFolder('build', 'distributions');
         new File(distributions, 'dist.txt').createNewFile();
 
-        temporaryFolder.newFile('Dockerfile') << """
+        file('Dockerfile') << """
             FROM alpine:3.2
             MAINTAINER id
             ADD build/distributions/dist.txt /tmp/
@@ -451,7 +451,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         File distributions = temporaryFolder.newFolder('build', 'distributions');
         new File(distributions, 'dist.txt').createNewFile();
 
-        temporaryFolder.newFile('Dockerfile') << """
+        file('Dockerfile') << """
             FROM alpine:3.2
             MAINTAINER id
             ADD build/distributions/dist.txt /tmp/

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -417,6 +417,63 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         execCond("docker rmi -f ${id}") || true
     }
 
+    def 'outputs from default distribution locations are added to the docker context'() {
+        given:
+        String id = 'id11'
+        File distributions = temporaryFolder.newFolder('build', 'distributions');
+        new File(distributions, 'dist.txt').createNewFile();
+
+        temporaryFolder.newFile('Dockerfile') << """
+            FROM alpine:3.2
+            MAINTAINER id
+            ADD build/distributions/dist.txt /tmp/
+        """.stripIndent()
+        buildFile << """
+            plugins {
+                id 'com.palantir.docker'
+            }
+            docker {
+                name '${id}'
+            }
+        """.stripIndent()
+        when:
+        BuildResult buildResult = with('docker').build()
+
+        then:
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
+        execCond("docker rmi -f ${id}") || true
+    }
+
+    def 'explicitly adding everything does not crash due to recursive overflow'() {
+        given:
+        String id = 'id12'
+        File distributions = temporaryFolder.newFolder('build', 'distributions');
+        new File(distributions, 'dist.txt').createNewFile();
+
+        temporaryFolder.newFile('Dockerfile') << """
+            FROM alpine:3.2
+            MAINTAINER id
+            ADD build/distributions/dist.txt /tmp/
+        """.stripIndent()
+        buildFile << """
+            plugins {
+                id 'com.palantir.docker'
+            }
+            docker {
+                name '${id}'
+                files '.'
+            }
+        """.stripIndent()
+        when:
+        BuildResult buildResult = with('docker').build()
+
+        then:
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
+        execCond("docker rmi -f ${id}") || true
+    }
+
     def 'check if compute name replaces the name correctly'() {
         expect:
         PalantirDockerPlugin.computeName(name, tag) == result


### PR DESCRIPTION
Hey guys,

I know you want new features/fixes to be properly tested but I do not want to start refactoring a 120 line method that has 0 test coverage. I will instead document the test cases here so you can hopefully include them in your test suite once you decide to make `PalantirDockerPlugin.apply` testable.

test1: should include `buildDir` in `buildDir/docker`
```
docker {
	name 'myorg/myapp'
	dependsOn distTar
}
```

test2: should not crash
```
docker {
	name 'myorg/myapp'
	files '.' // or "${projectDir}"
	dependsOn distTar
}
```
