### PR TITLE
Make push task depend on push tasks for each tag if tags are present

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -132,13 +132,14 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     })
                     tag.dependsOn subTask
 
-                    project.tasks.create('dockerPush' + taskTagName, Exec, {
+                    Exec pushSubTask = project.tasks.create('dockerPush' + taskTagName, Exec, {
                         group = 'Docker'
                         description = "Pushes the Docker image with tag '${tagName}' to configured Docker Hub"
                         workingDir dockerDir
                         commandLine 'docker', 'push', computeName(ext.name, tagName)
                         dependsOn tag
                     })
+                    push.dependsOn pushSubTask
                 }
             }
 


### PR DESCRIPTION
Issue #94 : Now, dockerPush will depend on all the dockerPushTagName tasks, which in turn depend on the dockerTagTagName tasks.