### PR TITLE
Change usage of dockerfile to file-object in documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ Configuration specifying all parameters:
 docker {
     name 'hub.docker.com/username/my-app:version'
     tags 'latest'
-    dockerfile 'Dockerfile'
+    dockerfile file('Dockerfile')
     files tasks.distTar.outputs, 'file1.txt', 'file2.txt'
     buildArgs([BUILD_VERSION: 'version'])
     labels(['key': 'value'])


### PR DESCRIPTION
Documentation was misleading when example is used as it is