### PR TITLE
Issue #126: Ability to specify network when using dockerRun

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -26,6 +26,7 @@ class DockerRunExtension {
 
     private String name
     private String image
+    private String network
     private List<String> command = ImmutableList.of()
     private Set<String> ports = ImmutableSet.of()
     private Map<String,String> env = ImmutableMap.of()
@@ -79,6 +80,14 @@ class DockerRunExtension {
 
     public void command(String... command) {
         this.command = ImmutableList.copyOf(command)
+    }
+
+    public void setNetwork(String network) {
+        this.network = network
+    }
+
+    public String getNetwork() {
+        return network
     }
 
     private void setEnvSingle(String key, String value) {

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -102,6 +102,30 @@ class DockerRunPluginTests extends AbstractPluginTest {
         offline.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is STOPPED./
     }
 
+    def 'can run container with configured network' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.docker-run'
+            }
+            dockerRun {
+                name 'bar-hostnetwork'
+                image 'alpine:3.2'
+                network 'host'
+            }
+        '''.stripIndent()
+
+		when:
+		BuildResult buildResult = with('dockerRemoveContainer', 'dockerRun', 'dockerNetworkModeStatus').build()
+
+		then:
+		buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+
+		buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+
+		buildResult.output =~ /(?m):dockerNetworkModeStatus\nDocker container 'bar-hostnetwork' is configured to run with 'host' network mode./
+	}
+
     def 'can optionally not daemonize'() {
         given:
         buildFile << '''


### PR DESCRIPTION
This implementation adds the ability to specify the 'network' mode for dockerRun.
Three execution branch may occur.
1. No network confugration was made
2. Network configuration was made and confirmed by docker inspect
3. Network configuration was made but differs to report from docker inspect