### PR TITLE
Specify Source & Target Compatibility (set to 1.7)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ if (System.env.CIRCLE_TEST_REPORTS) {
 group 'com.palantir.gradle.docker'
 version System.env.CIRCLE_TAG ?: gitVersion()
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource
     classifier 'sources'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ group 'com.palantir.gradle.docker'
 version System.env.CIRCLE_TAG ?: gitVersion()
 
 sourceCompatibility = 1.7
-targetCompatibility = 1.7
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource


### PR DESCRIPTION
Published plugin artifact inherits it's source and target java compatibility version, 1.8, from the build environment. This PR pins `sourceCompatibility` and `targetCompatibility` to the minimum possible version, 1.7, expanding the plugin's usage scope.