### PR TITLE
Allow for configuration of additional template tokens for docker compose files.

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
@@ -43,6 +43,10 @@ class DockerComposeExtension {
         this.templateTokens = templateTokens
     }
 
+    public void templateToken(String key, String value) {
+        this.templateTokens.put(key, value)
+    }
+
     Map<String, String> getTemplateTokens() {
         return templateTokens
     }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
@@ -15,6 +15,7 @@
  */
 package com.palantir.gradle.docker
 
+import com.google.common.collect.Maps
 import org.gradle.api.Project
 
 class DockerComposeExtension {
@@ -22,7 +23,7 @@ class DockerComposeExtension {
 
     private File template
     private File dockerComposeFile
-    private String currentImageName
+    private Map<String, String> templateTokens = Maps.newHashMap()
 
     public DockerComposeExtension(Project project) {
         this.project = project
@@ -38,12 +39,12 @@ class DockerComposeExtension {
         this.dockerComposeFile = project.file(dockerComposeFile)
     }
 
-    public void setCurrentImageName(String currentImageName) {
-        this.currentImageName = currentImageName
+    public void setTemplateTokens(Map<String, String> templateTokens) {
+        this.templateTokens = templateTokens
     }
 
-    String getCurrentImageName() {
-        return currentImageName
+    Map<String, String> getTemplateTokens() {
+        return templateTokens
     }
 
     File getTemplate() {

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
@@ -22,6 +22,7 @@ class DockerComposeExtension {
 
     private File template
     private File dockerComposeFile
+    private String currentImageName
 
     public DockerComposeExtension(Project project) {
         this.project = project
@@ -35,6 +36,14 @@ class DockerComposeExtension {
 
     public void setDockerComposeFile(Object dockerComposeFile) {
         this.dockerComposeFile = project.file(dockerComposeFile)
+    }
+
+    public void setCurrentImageName(String currentImageName) {
+        this.currentImageName = currentImageName
+    }
+
+    String getCurrentImageName() {
+        return currentImageName
     }
 
     File getTemplate() {

--- a/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
@@ -30,9 +30,9 @@ class GenerateDockerCompose extends DefaultTask {
             [("{{${it.group}:${it.name}}}"): it.version]
         }
 
-        if (ext.currentImageName != null) {
-            templateTokens.put("{{currentImageName}}", ext.currentImageName)
-        }
+        templateTokens.putAll(ext.templateTokens.collectEntries {
+            [("{{${it.key}}"): it.value]
+        })
 
         dockerComposeFile.withPrintWriter { writer ->
             template.eachLine { line ->

--- a/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
@@ -30,6 +30,10 @@ class GenerateDockerCompose extends DefaultTask {
             [("{{${it.group}:${it.name}}}"): it.version]
         }
 
+        if (ext.currentImageName != null) {
+            templateTokens.put("{{currentImageName}}", ext.currentImageName)
+        }
+
         dockerComposeFile.withPrintWriter { writer ->
             template.eachLine { line ->
                 writer.println this.replaceAll(line, templateTokens)

--- a/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
@@ -41,7 +41,7 @@ class DockerComposePluginTests extends AbstractPluginTest {
             }
 
             dockerCompose {
-                currentImageName 'snapshot.docker.registry/current-service:1.0.0-1-gabcabcd'
+                templateTokens(['currentImageName': 'snapshot.docker.registry/current-service:1.0.0-1-gabcabcd'])
             }
 
             dependencies {

--- a/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
@@ -28,6 +28,8 @@ class DockerComposePluginTests extends AbstractPluginTest {
               image: 'repository/service1:{{com.google.guava:guava}}'
             service2:
               image: 'repository/service2:{{org.slf4j:slf4j-api}}'
+            current-service:
+              image: '{{currentImageName}}'
         '''.stripIndent()
         buildFile << '''
             plugins {
@@ -36,6 +38,10 @@ class DockerComposePluginTests extends AbstractPluginTest {
 
             repositories {
                 jcenter()
+            }
+
+            dockerCompose {
+                currentImageName 'snapshot.docker.registry/current-service:1.0.0-1-gabcabcd'
             }
 
             dependencies {
@@ -53,6 +59,7 @@ class DockerComposePluginTests extends AbstractPluginTest {
         def dockerComposeText = file("docker-compose.yml").text
         dockerComposeText.contains("repository/service1:18.0")
         dockerComposeText.contains("repository/service2:1.7.10")
+        dockerComposeText.contains("snapshot.docker.registry/current-service:1.0.0-1-gabcabcd")
     }
 
     def 'Fails if docker-compose.yml.template has unmatched version tokens'() {


### PR DESCRIPTION
Allows for automated configuration of what the current image under testing ought to be, thereby avoiding the requirement of manual configuration when images are published to snapshot repositories vs release repositories.