### PR TITLE
Add ports to Docker Run Configuration Parameters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,7 @@ dockerRun {
     name 'my-container'
     image 'busybox'
     volumes 'hostvolume': '/containervolume'
+    ports '7080:5000'
     daemonize true
     env 'MYVAR1': 'MYVALUE1', 'MYVAR2': 'MYVALUE2'
     command 'sleep', '100'
@@ -233,6 +234,7 @@ dockerRun {
 - `volumes` optional map of volumes to mount in the container. The key is path
   to the host volume, relative to the project folder, the value is the exposed
   container volume path.
+- `ports` optional map of local port to container port.
 - `env` optional map of environment variables to supply to the running container.
   These must be exposed in the Dockerfile with `ENV` instructions.
 - `daemonize` defaults to true to daemonize the container after starting. However

--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,7 @@ dockerRun {
 - `volumes` optional map of volumes to mount in the container. The key is path
   to the host volume, relative to the project folder, the value is the exposed
   container volume path.
-- `ports` optional map of local port to container port.
+- `ports` optional mapping `local:container` of local port to container port.
 - `env` optional map of environment variables to supply to the running container.
   These must be exposed in the Dockerfile with `ENV` instructions.
 - `daemonize` defaults to true to daemonize the container after starting. However


### PR DESCRIPTION
This checkin adds ports mapping details to the Docker Run
Plugin configuration parameters.

Resolves #145 