### PR TITLE
Allow Docker binary location to be overridden by specifying environment variable GRADLE_DOCKER_BINARY

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,11 @@ docker {
 To build a docker container, run the `docker` task. To push that container to a
 docker repository, run the `dockerPush` task.
 
-Tag and Push tasks for each tag will be generated for each provided `tags` entry. 
+Tag and Push tasks for each tag will be generated for each provided `tags` entry.
+
+**Docker Environment Variables**
+- `GRADLE_DOCKER_BINARY` the path to the Docker binary to use; defaults to `docker` (and relies on any operating system
+  specific behaviour to resolve it, which [sometimes should not be relied upon](https://github.com/palantir/gradle-docker/issues/162)). 
 
 **Examples**
 
@@ -242,6 +246,10 @@ dockerRun {
 - `clean` (optional) a boolean argument which adds `--rm` to the `docker run`
   command to ensure that containers are cleaned up after running; defaults to `false`
 - `command` the command to run.
+
+**Docker Run Environment Variables**
+- `GRADLE_DOCKER_BINARY` the path to the Docker binary to use; defaults to `docker` (and relies on any operating system
+  specific behaviour to resolve it, which [sometimes should not be relied upon](https://github.com/palantir/gradle-docker/issues/162)).
 
 Tasks
 -----

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExecutor.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExecutor.groovy
@@ -15,7 +15,6 @@ trait DockerExecutor {
      * existence or executability of the returned file.
      */
     String getDockerBinary() {
-        System.err.println(getEnvironmentVariable('GRADLE_DOCKER_BINARY'))
         return getEnvironmentVariable('GRADLE_DOCKER_BINARY') ?: DEFAULT_DOCKER_BINARY
     }
 

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExecutor.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExecutor.groovy
@@ -1,0 +1,33 @@
+package com.palantir.gradle.docker
+
+import com.google.common.annotations.VisibleForTesting
+
+/**
+ * A trait for classes which might execute the Docker process. Provides a mechanism for them to retrieve the path to the
+ * Docker binary via {@link #getDockerBinary}
+ */
+trait DockerExecutor {
+    private static final String DEFAULT_DOCKER_BINARY = "docker"
+
+    /**
+     * @return the path to the Docker binary. If the <pre>GRADLE_DOCKER_BINARY</pre> environment variable is specified,
+     * it will be returned, otherwise defaults to {@link #DEFAULT_DOCKER_BINARY}. No guarantees are made about the
+     * existence or executability of the returned file.
+     */
+    String getDockerBinary() {
+        System.err.println(getEnvironmentVariable('GRADLE_DOCKER_BINARY'))
+        return getEnvironmentVariable('GRADLE_DOCKER_BINARY') ?: DEFAULT_DOCKER_BINARY
+    }
+
+    /**
+     * Gets environment variables based on the given parameter. {@link VisibleForTesting} because there's no real world
+     * reason to override this, but modifying the environment is not trivial in testing.
+     *
+     * @param environment variable name
+     * @return the environment variable value for the given name.
+     */
+    @VisibleForTesting
+    String getEnvironmentVariable(String name) {
+        return System.getenv(name)
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -26,7 +26,7 @@ import org.gradle.internal.logging.text.StyledTextOutput.Style
 
 import com.google.common.collect.Lists
 
-class DockerRunPlugin implements Plugin<Project> {
+class DockerRunPlugin implements Plugin<Project>, DockerExecutor {
     @Override
     void apply(Project project) {
         DockerRunExtension ext = project.extensions.create('dockerRun', DockerRunExtension)
@@ -61,7 +61,7 @@ class DockerRunPlugin implements Plugin<Project> {
         project.afterEvaluate {
             dockerRunStatus.with {
                 standardOutput = new ByteArrayOutputStream()
-                commandLine 'docker', 'inspect', '--format={{.State.Running}}', ext.name
+                commandLine dockerBinary, 'inspect', '--format={{.State.Running}}', ext.name
                 doLast {
                     if (standardOutput.toString().trim() != 'true') {
                         println "Docker container '${ext.name}' is STOPPED."
@@ -74,7 +74,7 @@ class DockerRunPlugin implements Plugin<Project> {
 
             dockerNetworkModeStatus.with {
                 standardOutput = new ByteArrayOutputStream()
-                commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', ext.name
+                commandLine dockerBinary, 'inspect', '--format={{.HostConfig.NetworkMode}}', ext.name
                 doLast {
                     def networkMode = standardOutput.toString().trim()
                     if (networkMode == 'default') {
@@ -94,7 +94,7 @@ class DockerRunPlugin implements Plugin<Project> {
 
             dockerRun.with {
                 List<String> args = Lists.newArrayList()
-                args.addAll(['docker', 'run'])
+                args.addAll([dockerBinary, 'run'])
                 if (ext.daemonize) {
                   args.add('-d')
                 }
@@ -131,11 +131,11 @@ class DockerRunPlugin implements Plugin<Project> {
             }
 
             dockerStop.with {
-                commandLine 'docker', 'stop', ext.name
+                commandLine dockerBinary, 'stop', ext.name
             }
 
             dockerRemoveContainer.with {
-                commandLine 'docker', 'rm', ext.name
+                commandLine dockerBinary, 'rm', ext.name
             }
         }
     }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -35,7 +35,7 @@ import org.gradle.api.tasks.bundling.Zip
 import javax.inject.Inject
 import java.util.regex.Pattern
 
-class PalantirDockerPlugin implements Plugin<Project> {
+class PalantirDockerPlugin implements Plugin<Project>, DockerExecutor {
 
     private static final Logger log = Logging.getLogger(PalantirDockerPlugin.class)
     private static final Pattern LABEL_KEY_PATTERN = Pattern.compile('^[a-z0-9.-]*$')
@@ -125,7 +125,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                         group = 'Docker'
                         description = "Tags Docker image with tag '${tagName}'"
                         workingDir dockerDir
-                        commandLine 'docker', 'tag', "${ -> ext.name}", "${ -> computeName(ext.name, tagName)}"
+                        commandLine dockerBinary, 'tag', "${ -> ext.name}", "${ -> computeName(ext.name, tagName)}"
                         dependsOn exec
                     })
                     tag.dependsOn subTask
@@ -134,7 +134,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                         group = 'Docker'
                         description = "Pushes the Docker image with tag '${tagName}' to configured Docker Hub"
                         workingDir dockerDir
-                        commandLine 'docker', 'push', "${ -> computeName(ext.name, tagName)}"
+                        commandLine dockerBinary, 'push', "${ -> computeName(ext.name, tagName)}"
                         dependsOn tag
                     })
                 }
@@ -142,7 +142,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
 
             push.with {
                 workingDir dockerDir
-                commandLine 'docker', 'push', "${ -> ext.name}"
+                commandLine dockerBinary, 'push', "${ -> ext.name}"
             }
 
             dockerfileZip.with {
@@ -152,7 +152,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
     }
 
     private List<String> buildCommandLine(DockerExtension ext) {
-        List<String> buildCommandLine = ['docker', 'build']
+        List<String> buildCommandLine = [dockerBinary, 'build']
         if (ext.noCache) {
             buildCommandLine.add '--no-cache'
         }

--- a/src/test/groovy/com/palantir/gradle/docker/DockerExecutorTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerExecutorTest.groovy
@@ -1,0 +1,34 @@
+package com.palantir.gradle.docker
+
+import spock.lang.Specification
+
+class DockerExecutorTest extends Specification {
+    def 'defaults to docker'() {
+        given:
+        def executor = [].withTraits(DockerExecutor)
+
+        when:
+        String dockerBinary = executor.dockerBinary
+
+        then:
+        dockerBinary == 'docker'
+    }
+
+    def 'uses environment variable overrides'() {
+        given:
+        def executor = new EnvironmentSpecifyingExecutor()
+
+        when:
+        String dockerBinary = executor.dockerBinary
+
+        then:
+        dockerBinary == '/the/docker/binary'
+    }
+
+    private static class EnvironmentSpecifyingExecutor implements DockerExecutor {
+        @Override
+        String getEnvironmentVariable(String name) {
+            return name == 'GRADLE_DOCKER_BINARY' ? '/the/docker/binary' : null
+        }
+    }
+}

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -18,7 +18,7 @@ package com.palantir.gradle.docker
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
-class DockerRunPluginTests extends AbstractPluginTest {
+class DockerRunPluginTests extends AbstractPluginTest implements DockerExecutor {
 
     def 'can run, status, and stop a container made by the docker plugin' () {
         given:
@@ -63,7 +63,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
         offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         offline.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
 
-        execCond('docker rmi -f foo-image')
+        execCond("$dockerBinary rmi -f foo-image")
     }
 
     def 'can run, status, and stop a container' () {

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.artifacts.mvnsettings.DefaultMavenSettingsProvide
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 
-class PalantirDockerPluginTests extends AbstractPluginTest {
+class PalantirDockerPluginTests extends AbstractPluginTest implements DockerExecutor {
 
     def 'fail when missing docker configuration'() {
         given:
@@ -79,8 +79,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'check plugin creates a docker container with non-standard Dockerfile name'() {
@@ -107,8 +107,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'check files are correctly added to docker context'() {
@@ -137,8 +137,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'Publishes "docker" dependencies via "docker" component'() {
@@ -308,12 +308,12 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         buildResult.task(':dockerTag').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        exec("docker inspect --format '{{.Author}}' ${id}:latest") == "'${id}'\n"
-        exec("docker inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
-        execCond("docker rmi -f ${id}:another")
-        execCond("docker rmi -f ${id}:latest")
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}:latest") == "'${id}'\n"
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
+        execCond("$dockerBinary rmi -f ${id}")
+        execCond("$dockerBinary rmi -f ${id}:another")
+        execCond("$dockerBinary rmi -f ${id}:latest")
     }
 
     def 'running tag task creates images with specified tags'() {
@@ -354,12 +354,12 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         buildResult.task(':dockerTag').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        exec("docker inspect --format '{{.Author}}' ${id}:latest") == "'${id}'\n"
-        exec("docker inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
-        execCond("docker rmi -f ${id}:latest")
-        execCond("docker rmi -f ${id}:another")
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}:latest") == "'${id}'\n"
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
+        execCond("$dockerBinary rmi -f ${id}")
+        execCond("$dockerBinary rmi -f ${id}:latest")
+        execCond("$dockerBinary rmi -f ${id}:another")
     }
 
     def 'build args are correctly processed'() {
@@ -388,9 +388,9 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
         then:
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Config.Env}}' ${id}").contains('ENV_BUILD_ARG_NO_DEFAULT=gradleBuildArg')
-        exec("docker inspect --format '{{.Config.Env}}' ${id}").contains('BUILD_ARG_WITH_DEFAULT=gradleOverrideBuildArg')
-        execCond("docker rmi -f ${id}")
+        exec("$dockerBinary inspect --format '{{.Config.Env}}' ${id}").contains('ENV_BUILD_ARG_NO_DEFAULT=gradleBuildArg')
+        exec("$dockerBinary inspect --format '{{.Config.Env}}' ${id}").contains('BUILD_ARG_WITH_DEFAULT=gradleOverrideBuildArg')
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'rebuilding an image does it from scratch when "noCache" parameter is set'() {
@@ -424,7 +424,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult1.task(':docker').outcome == TaskOutcome.SUCCESS
         buildResult2.task(':docker').outcome == TaskOutcome.SUCCESS
         imageID1 != imageID2
-        execCond("docker rmi -f ${id}")
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'base image is pulled when "pull" parameter is set'() {
@@ -451,7 +451,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         buildResult.output.contains 'Pulling from library/alpine'
-        execCond("docker rmi -f ${id}")
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'can add files from project directory to build context'() {
@@ -480,8 +480,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
-        execCond("docker rmi -f ${id}")
+        exec("$dockerBinary inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'when adding a project-dir file and a Tar file, then they both end up (unzipped) in the docker image'() {
@@ -523,7 +523,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':myTgz').outcome == TaskOutcome.SUCCESS
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        execCond("docker rmi -f ${id}")
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'can build Docker image from standard Gradle distribution plugin'() {
@@ -561,7 +561,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':distTar').outcome == TaskOutcome.SUCCESS
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        execCond("docker rmi -f ${id}")
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'check labels are correctly applied to image'() {
@@ -585,8 +585,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
         then:
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
-        exec("docker inspect --format '{{.Config.Labels}}' ${id}").contains("test-label")
-        execCond("docker rmi -f ${id}")
+        exec("$dockerBinary inspect --format '{{.Config.Labels}}' ${id}").contains("test-label")
+        execCond("$dockerBinary rmi -f ${id}")
     }
 
     def 'fail with bad label key character'() {


### PR DESCRIPTION
## Notes

Allow Docker binary location to be overriden by specifying environment variable `GRADLE_DOCKER_BINARY`.

#### Justification

Not all build environments have `docker` in the path available during Gradle build.  For example, on Mac Java's `ProcessBuilder` (used by Gradle `Exec`) only considers `/usr/bin` and not `/usr/local/bin`, despite any `PATH` environment variables (see [this issue](https://github.com/palantir/gradle-docker/issues/162)).  This change allows builders to explicitly provide their docker location (e.g. `/usr/local/bin/docker`).  On my system, Docker was installed using Homebrew which put it in local bin and SIP prevents symlinking into bin.

#### Environment variable vs parameter in buildfile

I preferred an environment variable instead of providing `dockerBinary` option in the buildfile (like one other plugin does) to make this more portable.  Consumers of a library using this plugin should not be forced to use a specific binary path (definitely breaks in a cross-platform world too).  Instead, they can set this environment variable once and things will just work.

## Testing

* `gradle-docker$ gradle build`
  * Existing unit tests. These assume the default `docker` and keep working on platforms where that works. However, I modified them to also use the environment variable, which allowed them to pass on my system.
  * Added a new unit test which overrides the behaviour of getting an environment variable and tests the `DockerExecutor` trait directly to prove it uses the env but falls back to `docker`.  I chose to do this because you cannot trivially (and in a well-supported cross-platform manner) modify environment variables.
* `my-own-gradle-project$ GRADLE_DOCKER_BINARY=/usr/local/bin/docker gradle docker`
 * The Gradle project I'm working on which uses this plugin now finally works when the variable is set!