### PR TITLE
Add support for getting a dynamic host port

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -107,11 +107,11 @@ class DockerRunExtension {
         for (String port : ports) {
             String[] mapping = port.split(':', 2)
             if (mapping.length == 1) {
-                checkPortIsValid(mapping[0])
+                checkContainerPortIsValid(mapping[0])
                 builder.add("${mapping[0]}:${mapping[0]}")
             } else {
-                checkPortIsValid(mapping[0])
-                checkPortIsValid(mapping[1])
+                checkHostPortIsValid(mapping[0])
+                checkContainerPortIsValid(mapping[1])
                 builder.add("${mapping[0]}:${mapping[1]}")
             }
         }
@@ -122,9 +122,13 @@ class DockerRunExtension {
       this.volumes = ImmutableMap.copyOf(volumes)
     }
 
-    private static void checkPortIsValid(String port) {
+    private static void checkHostPortIsValid(String port) {
         int val = Integer.parseInt(port)
-        Preconditions.checkArgument(0 < val && val <= 65536, "Port must be in the range [1,65536]")
+        Preconditions.checkArgument(0 <= val && val <= 65536, "Host port must be in the range [0,65536]")
     }
 
+    private static void checkContainerPortIsValid(String port) {
+        int val = Integer.parseInt(port)
+        Preconditions.checkArgument(0 < val && val <= 65536, "Container port must be in the range [1,65536]")
+    }
 }

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -126,6 +126,50 @@ class DockerRunPluginTests extends AbstractPluginTest {
 		buildResult.output =~ /(?m):dockerNetworkModeStatus\nDocker container 'bar-hostnetwork' is configured to run with 'host' network mode./
 	}
 
+    def 'can run container with configured host port' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.docker-run'
+            }
+            dockerRun {
+                name 'bar-hostport'
+                image 'alpine:3.2'
+                ports '80:8080'
+            }
+        '''.stripIndent()
+
+		when:
+		BuildResult buildResult = with('dockerRemoveContainer', 'dockerRun').build()
+
+		then:
+		buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+
+		buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+	}
+
+    def 'can run container with configured host port 0' () {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.docker-run'
+            }
+            dockerRun {
+                name 'bar-hostport0'
+                image 'alpine:3.2'
+                ports '0:8080'
+            }
+        '''.stripIndent()
+
+		when:
+		BuildResult buildResult = with('dockerRemoveContainer', 'dockerRun').build()
+
+		then:
+		buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+
+		buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+	}
+
     def 'can optionally not daemonize'() {
         given:
         buildFile << '''


### PR DESCRIPTION
Fixes #171

Ultimately I think it would better to stop using the given port as the host port when only one value is specified and instead dynamically allocate a host port to match the `docker run` behavior.