### PR TITLE
fix issue #149 and issue #151

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -73,10 +73,16 @@ class PalantirDockerPlugin implements Plugin<Project> {
             dependsOn prepare
         })
 
+        Task tag = project.tasks.create('dockerTag', {
+          group = 'Docker'
+          description = 'Applies all tags to the Docker image.'
+          dependsOn exec
+        })
+
         Exec push = project.tasks.create('dockerPush', Exec, {
             group = 'Docker'
             description = 'Pushes named Docker image to configured Docker Hub.'
-            dependsOn exec
+            dependsOn tag
         })
 
         Zip dockerfileZip = project.tasks.create('dockerfileZip', Zip, {
@@ -114,10 +120,6 @@ class PalantirDockerPlugin implements Plugin<Project> {
             }
 
             if (!ext.tags.isEmpty()) {
-                Task tag = project.tasks.create('dockerTag', {
-                    group = 'Docker'
-                    description = 'Applies all tags to the Docker image.'
-                })
 
                 ext.tags.each { tagName ->
                     String taskTagName = ucfirst(tagName)
@@ -135,7 +137,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                         description = "Pushes the Docker image with tag '${tagName}' to configured Docker Hub"
                         workingDir dockerDir
                         commandLine 'docker', 'push', "${ -> computeName(ext.name, tagName)}"
-                        dependsOn tag
+                        dependsOn subTask
                     })
                 }
             }

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -227,30 +227,6 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':tasks').outcome == TaskOutcome.SUCCESS
     }
 
-    def 'no tag task when no tags defined'() {
-        given:
-        String id = 'id4'
-        file('Dockerfile') << """
-            FROM alpine:3.2
-            MAINTAINER ${id}
-        """.stripIndent()
-        buildFile << """
-            plugins {
-                id 'com.palantir.docker'
-            }
-
-            docker {
-                name '${id}'
-            }
-        """.stripIndent()
-
-        when:
-        BuildResult buildResult = with('tasks').build()
-
-        then:
-        !buildResult.output.contains('dockerTag')
-    }
-
     def 'tag and push tasks created for each tag'() {
         given:
         String id = 'id5'

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -290,6 +290,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         execCond("docker rmi -f ${id}")
         execCond("docker rmi -f ${id}:another")
         execCond("docker rmi -f ${id}:latest")
+        
     }
 
     def 'running tag task creates images with specified tags'() {


### PR DESCRIPTION
- (issue #151) Create the dockerTag task outside of the afterEvaluate so that it can be referenced during build configuration
- (issue #149) Make dockerPush depend on dockerTag
- make dockerPush\<tag\> only depend on dockerTag\<tag\>