### PR TITLE
Support tag task name for 'tags'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ automatically include outputs of task dependencies in the Docker build context.
 - `name` the name to use for this container, may include a tag
 - `tags` (deprecated) (optional) an argument list of tags to create; any tag in `name` will
   be stripped before applying a specific tag; defaults to the empty set
-- `tag` (optional) defined a tag with task name
+- `tag` (optional) a tag to create with a specified task name
 - `dockerfile` (optional) the dockerfile to use for building the image; defaults to
   `project.file('Dockerfile')` and must be a file object
 - `files` (optional) an argument list of files to be included in the Docker build context, evaluated per `Project#files`. For example, `files tasks.distTar.outputs` adds the TAR/TGZ file produced by the `distTar` tasks, and `files tasks.distTar.outputs, 'my-file.txt'` adds the archive in addition to file `my-file.txt` from the project root directory. The specified files are collected in a Gradle CopySpec which may be copied `into` the Docker build context directory. The underlying CopySpec may also be used to copy entire directories into the build context. The following example adds the aforementioned archive and text file to the CopySpec, uses the CopySpec to add all files `from` `src/myDir` into the CopySpec, then finally executes the copy `into` the docker build context directory `myDir`
@@ -82,7 +82,7 @@ Configuration specifying all parameters:
 docker {
     name 'hub.docker.com/username/my-app:version'
     tags 'latest' // deprecated, use 'tag'
-    tag 'privateRepo', 'my.repo.com/username/my-app:version'
+    tag 'myRegistry', 'my.registry.com/username/my-app:version'
     dockerfile file('Dockerfile')
     files tasks.distTar.outputs, 'file1.txt', 'file2.txt'
     buildArgs([BUILD_VERSION: 'version'])
@@ -259,7 +259,7 @@ Tasks
    * `dockerTag<tag>`: tag the docker image with `<tag>`
    * `dockerPush`: push the specified image to a docker repository
    * `dockerPush<tag>`: push the `<tag>` docker image to a docker repository
-   * `dockerTagsPush`: push all tagged Docker images to configured Docker Hub
+   * `dockerTagsPush`: push all tagged docker images to a docker repository
    * `dockerPrepare`: prepare to build a docker image by copying
      dependent task outputs, referenced files, and `dockerfile` into a temporary
      directory

--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,9 @@ automatically include outputs of task dependencies in the Docker build context.
 
 **Docker Configuration Parameters**
 - `name` the name to use for this container, may include a tag
-- `tags` (optional) an argument list of tags to create; any tag in `name` will
+- `tags` (deprecated) (optional) an argument list of tags to create; any tag in `name` will
   be stripped before applying a specific tag; defaults to the empty set
+- `tag` (optional) defined a tag with task name
 - `dockerfile` (optional) the dockerfile to use for building the image; defaults to
   `project.file('Dockerfile')` and must be a file object
 - `files` (optional) an argument list of files to be included in the Docker build context, evaluated per `Project#files`. For example, `files tasks.distTar.outputs` adds the TAR/TGZ file produced by the `distTar` tasks, and `files tasks.distTar.outputs, 'my-file.txt'` adds the archive in addition to file `my-file.txt` from the project root directory. The specified files are collected in a Gradle CopySpec which may be copied `into` the Docker build context directory. The underlying CopySpec may also be used to copy entire directories into the build context. The following example adds the aforementioned archive and text file to the CopySpec, uses the CopySpec to add all files `from` `src/myDir` into the CopySpec, then finally executes the copy `into` the docker build context directory `myDir`
@@ -53,7 +54,7 @@ docker {
 To build a docker container, run the `docker` task. To push that container to a
 docker repository, run the `dockerPush` task.
 
-Tag and Push tasks for each tag will be generated for each provided `tags` entry.
+Tag and Push tasks for each tag will be generated for each provided `tag` and `tags` entry.
 
 **Examples**
 
@@ -80,7 +81,8 @@ Configuration specifying all parameters:
 ```gradle
 docker {
     name 'hub.docker.com/username/my-app:version'
-    tags 'latest'
+    tags 'latest' // deprecated, use 'tag'
+    tag 'privateRepo', 'my.repo.com/username/my-app:version'
     dockerfile file('Dockerfile')
     files tasks.distTar.outputs, 'file1.txt', 'file2.txt'
     buildArgs([BUILD_VERSION: 'version'])
@@ -257,6 +259,8 @@ Tasks
    * `dockerTag<tag>`: tag the docker image with `<tag>`
    * `dockerPush`: push the specified image to a docker repository
    * `dockerPush<tag>`: push the `<tag>` docker image to a docker repository
+   * `dockerTagsPush`: push all tagged Docker images to configured Docker Hub
+   * `dockerAllPush`: push all tagged Docker images and named Docker image to configured Docker Hub
    * `dockerPrepare`: prepare to build a docker image by copying
      dependent task outputs, referenced files, and `dockerfile` into a temporary
      directory

--- a/readme.md
+++ b/readme.md
@@ -260,7 +260,6 @@ Tasks
    * `dockerPush`: push the specified image to a docker repository
    * `dockerPush<tag>`: push the `<tag>` docker image to a docker repository
    * `dockerTagsPush`: push all tagged Docker images to configured Docker Hub
-   * `dockerAllPush`: push all tagged Docker images and named Docker image to configured Docker Hub
    * `dockerPrepare`: prepare to build a docker image by copying
      dependent task outputs, referenced files, and `dockerfile` into a temporary
      directory

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -103,9 +103,9 @@ class DockerExtension {
     }
 
     public void tag(String taskName, String tag) {
-        if (namedTags.putIfAbsent(taskName, tag) == null) {
+        if (namedTags.putIfAbsent(taskName, tag) != null) {
             StyledTextOutput o = project.services.get(StyledTextOutputFactory.class).create(DockerExtension)
-            o.withStyle(StyledTextOutput.Style.Error).println("WARNING: Task name '${taskName}' of docker tag '${tag}' is existed.")
+            o.withStyle(StyledTextOutput.Style.Error).println("WARNING: Task name '${taskName}' is existed.")
         }
     }
 

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -138,16 +138,16 @@ class PalantirDockerPlugin implements Plugin<Project> {
             }
 
             if (!ext.unresolvedTags.isEmpty()) {
-                ext.unresolvedTags.each { markedTagName ->
-                    String taskName = generateTagTaskName(markedTagName)
+                ext.unresolvedTags.each { unresolvedTagName ->
+                    String taskName = generateTagTaskName(unresolvedTagName)
 
                     if (tags.containsKey(taskName)) {
-                        throw new GradleException("Task name '${taskName}' of docker tag '${tagName}' is existed.")
+                        throw new GradleException("Task name '${taskName}' of docker tag '${unresolvedTagName}' is existed.")
                     }
 
                     tags[taskName] = [
-                            rawTagName          : markedTagName,
-                            resolveTagNameAction: { -> computeName(ext.name, markedTagName) }
+                            rawTagName          : unresolvedTagName,
+                            resolveTagNameAction: { -> computeName(ext.name, unresolvedTagName) }
                     ]
                 }
             }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -92,12 +92,6 @@ class PalantirDockerPlugin implements Plugin<Project> {
             description = 'Pushes all tagged Docker images to configured Docker Hub.'
         })
 
-        Task pushAll = project.tasks.create('dockerAllPush', {
-            group = 'Docker'
-            description = 'Pushes all tagged Docker images and named Docker image to configured Docker Hub.'
-            dependsOn push, pushAllTags
-        })
-
         Zip dockerfileZip = project.tasks.create('dockerfileZip', Zip, {
             group = 'Docker'
             description = 'Bundles the configured Dockerfile in a zip file'

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -139,12 +139,12 @@ class PalantirDockerPlugin implements Plugin<Project> {
 
                     if (tags.containsKey(taskName)) {
                         throw new IllegalArgumentException("Task name '${taskName}' is existed.")
-                    }else{
-                        tags[taskName] = [
-                                tagName: unresolvedTagName,
-                                tagTask: { -> computeName(ext.name, unresolvedTagName) }
-                        ]
                     }
+                    
+                    tags[taskName] = [
+                            tagName: unresolvedTagName,
+                            tagTask: { -> computeName(ext.name, unresolvedTagName) }
+                    ]
                 }
             }
 

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -31,6 +31,8 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.bundling.Zip
+import org.gradle.internal.logging.text.StyledTextOutput
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 import javax.inject.Inject
 import java.util.regex.Pattern
@@ -135,20 +137,21 @@ class PalantirDockerPlugin implements Plugin<Project> {
                         tagName: tagName,
                         tagTask: { -> tagName }
                 ]]
-            }.asImmutable()
+            }
 
             if (!ext.tags.isEmpty()) {
                 ext.tags.each { unresolvedTagName ->
                     String taskName = generateTagTaskName(unresolvedTagName)
 
                     if (tags.containsKey(taskName)) {
-                        throw new GradleException("Task name '${taskName}' of docker tag '${unresolvedTagName}' is existed.")
+                        StyledTextOutput o = project.services.get(StyledTextOutputFactory.class).create(DockerExtension)
+                        o.withStyle(StyledTextOutput.Style.Error).println("WARNING: Task name '${taskName}' is existed.")
+                    }else{
+                        tags[taskName] = [
+                                tagName: unresolvedTagName,
+                                tagTask: { -> computeName(ext.name, unresolvedTagName) }
+                        ]
                     }
-
-                    tags[taskName] = [
-                            tagName: unresolvedTagName,
-                            tagTask: { -> computeName(ext.name, unresolvedTagName) }
-                    ]
                 }
             }
 

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -242,6 +242,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
             docker {
                 name '${id}'
                 tags 'latest', 'another', 'withTaskName@2.0', 'newImageName@${id}-new:latest'
+                tag 'withTaskNameByTag', '${id}:new-latest'
             }
         """.stripIndent()
 
@@ -253,12 +254,13 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.output.contains('dockerTagAnother')
         buildResult.output.contains('dockerTagWithTaskName')
         buildResult.output.contains('dockerTagNewImageName')
+        buildResult.output.contains('dockerTagWithTaskNameByTag')
         buildResult.output.contains('dockerPushLatest')
         buildResult.output.contains('dockerPushAnother')
         buildResult.output.contains('dockerPushWithTaskName')
         buildResult.output.contains('dockerPushNewImageName')
+        buildResult.output.contains('dockerPushWithTaskNameByTag')
     }
-
 
     def 'does not throw if name is configured after evaluation phase'() {
         given:
@@ -274,6 +276,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
             docker {
                 tags 'latest', 'another', 'withTaskName@2.0', 'newImageName@${id}-new:latest'
+                tag 'withTaskNameByTag', '${id}:new-latest'
             }
 
             afterEvaluate {
@@ -293,11 +296,13 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         exec("docker inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}:2.0") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}-new:latest") == "'${id}'\n"
+        exec("docker inspect --format '{{.Author}}' ${id}:new-latest") == "'${id}'\n"
         execCond("docker rmi -f ${id}")
         execCond("docker rmi -f ${id}:another")
         execCond("docker rmi -f ${id}:latest")
         execCond("docker rmi -f ${id}:2.0")
         execCond("docker rmi -f ${id}-new:latest")
+        execCond("docker rmi -f ${id}:new-latest")
     }
 
     def 'running tag task creates images with specified tags'() {
@@ -315,6 +320,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
             docker {
                 name 'fake-service-name'
                 tags 'latest', 'another', 'withTaskName@2.0', 'newImageName@${id}-new:latest'
+                tag 'withTaskNameByTag', '${id}:new-latest'
             }
 
             afterEvaluate {
@@ -327,6 +333,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
                     println "ANOTHER: \${tasks.dockerTagAnother.commandLine}"
                     println "WITH_TASK_NAME: \${tasks.dockerTagWithTaskName.commandLine}"
                     println "NEW_IMAGE_NAME: \${tasks.dockerTagNewImageName.commandLine}"
+                    println "WITH_TASK_NAME_BY_TAG: \${tasks.dockerTagWithTaskNameByTag.commandLine}"
                 }
             }
         """.stripIndent()
@@ -339,6 +346,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.output.contains("ANOTHER: [docker, tag, ${id}, ${id}:another]")
         buildResult.output.contains("WITH_TASK_NAME: [docker, tag, ${id}, ${id}:2.0]")
         buildResult.output.contains("NEW_IMAGE_NAME: [docker, tag, ${id}, ${id}-new:latest]")
+        buildResult.output.contains("WITH_TASK_NAME_BY_TAG: [docker, tag, ${id}, ${id}:new-latest]")
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         buildResult.task(':dockerTag').outcome == TaskOutcome.SUCCESS
@@ -347,11 +355,13 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         exec("docker inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}:2.0") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}-new:latest") == "'${id}'\n"
+        exec("docker inspect --format '{{.Author}}' ${id}:new-latest") == "'${id}'\n"
         execCond("docker rmi -f ${id}")
         execCond("docker rmi -f ${id}:latest")
         execCond("docker rmi -f ${id}:another")
         execCond("docker rmi -f ${id}:2.0")
         execCond("docker rmi -f ${id}-new:latest")
+        execCond("docker rmi -f ${id}:new-latest")
     }
 
     def 'build args are correctly processed'() {

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -241,7 +241,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
             docker {
                 name '${id}'
-                tags 'latest', 'another'
+                tags 'latest', 'another', 'withTaskName@2.0', 'newImageName@${id}-new:latest'
             }
         """.stripIndent()
 
@@ -251,8 +251,12 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.output.contains('dockerTagLatest')
         buildResult.output.contains('dockerTagAnother')
+        buildResult.output.contains('dockerTagWithTaskName')
+        buildResult.output.contains('dockerTagNewImageName')
         buildResult.output.contains('dockerPushLatest')
         buildResult.output.contains('dockerPushAnother')
+        buildResult.output.contains('dockerPushWithTaskName')
+        buildResult.output.contains('dockerPushNewImageName')
     }
 
 
@@ -269,7 +273,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
             }
 
             docker {
-                tags 'latest', 'another'
+                tags 'latest', 'another', 'withTaskName@2.0', 'newImageName@${id}-new:latest'
             }
 
             afterEvaluate {
@@ -278,7 +282,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         """.stripIndent()
 
         when:
-        BuildResult buildResult = with('dockerTag').build()
+        BuildResult buildResult = with('dockerTag', "--stacktrace").build()
 
         then:
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
@@ -287,10 +291,13 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}:latest") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
+        exec("docker inspect --format '{{.Author}}' ${id}:2.0") == "'${id}'\n"
+        exec("docker inspect --format '{{.Author}}' ${id}-new:latest") == "'${id}'\n"
         execCond("docker rmi -f ${id}")
         execCond("docker rmi -f ${id}:another")
         execCond("docker rmi -f ${id}:latest")
-        
+        execCond("docker rmi -f ${id}:2.0")
+        execCond("docker rmi -f ${id}-new:latest")
     }
 
     def 'running tag task creates images with specified tags'() {
@@ -307,7 +314,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
             docker {
                 name 'fake-service-name'
-                tags 'latest', 'another'
+                tags 'latest', 'another', 'withTaskName@2.0', 'newImageName@${id}-new:latest'
             }
 
             afterEvaluate {
@@ -318,6 +325,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
                 doLast {
                     println "LATEST: \${tasks.dockerTagLatest.commandLine}"
                     println "ANOTHER: \${tasks.dockerTagAnother.commandLine}"
+                    println "WITH_TASK_NAME: \${tasks.dockerTagWithTaskName.commandLine}"
+                    println "NEW_IMAGE_NAME: \${tasks.dockerTagNewImageName.commandLine}"
                 }
             }
         """.stripIndent()
@@ -326,17 +335,23 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         BuildResult buildResult = with('dockerTag', 'printInfo').build()
 
         then:
-        buildResult.output.contains("LATEST: [docker, tag, id6, id6:latest]")
-        buildResult.output.contains("ANOTHER: [docker, tag, id6, id6:another]")
+        buildResult.output.contains("LATEST: [docker, tag, ${id}, ${id}:latest]")
+        buildResult.output.contains("ANOTHER: [docker, tag, ${id}, ${id}:another]")
+        buildResult.output.contains("WITH_TASK_NAME: [docker, tag, ${id}, ${id}:2.0]")
+        buildResult.output.contains("NEW_IMAGE_NAME: [docker, tag, ${id}, ${id}-new:latest]")
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
         buildResult.task(':dockerTag').outcome == TaskOutcome.SUCCESS
         exec("docker inspect --format '{{.Author}}' ${id}") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}:latest") == "'${id}'\n"
         exec("docker inspect --format '{{.Author}}' ${id}:another") == "'${id}'\n"
+        exec("docker inspect --format '{{.Author}}' ${id}:2.0") == "'${id}'\n"
+        exec("docker inspect --format '{{.Author}}' ${id}-new:latest") == "'${id}'\n"
         execCond("docker rmi -f ${id}")
         execCond("docker rmi -f ${id}:latest")
         execCond("docker rmi -f ${id}:another")
+        execCond("docker rmi -f ${id}:2.0")
+        execCond("docker rmi -f ${id}-new:latest")
     }
 
     def 'build args are correctly processed'() {
@@ -602,6 +617,36 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         "host/v1:1"      | "latest" | "host/v1:latest"
         "host:port/v1"   | "latest" | "host:port/v1:latest"
         "host:port/v1:1" | "latest" | "host:port/v1:latest"
+        "v1"             | "name@latest" | "v1:latest"
+        "v1:1"           | "name@latest" | "v1:latest"
+        "host/v1"        | "name@latest" | "host/v1:latest"
+        "host/v1:1"      | "name@latest" | "host/v1:latest"
+        "host:port/v1"   | "name@latest" | "host:port/v1:latest"
+        "host:port/v1:1" | "name@latest" | "host:port/v1:latest"
+        "v1"             | "name@v2:latest" | "v2:latest"
+        "v1:1"           | "name@v2:latest" | "v2:latest"
+        "host/v1"        | "name@v2:latest" | "v2:latest"
+        "host/v1:1"      | "name@v2:latest" | "v2:latest"
+        "host:port/v1"   | "name@v2:latest" | "v2:latest"
+        "host:port/v1:1" | "name@v2:latest" | "v2:latest"
+        "v1"             | "name@host/v2" | "host/v2"
+        "v1:1"           | "name@host/v2" | "host/v2"
+        "host/v1"        | "name@host/v2" | "host/v2"
+        "host/v1:1"      | "name@host/v2" | "host/v2"
+        "host:port/v1"   | "name@host/v2" | "host/v2"
+        "host:port/v1:1" | "name@host/v2" | "host/v2"
+        "v1"             | "name@host/v2:2" | "host/v2:2"
+        "v1:1"           | "name@host/v2:2" | "host/v2:2"
+        "host/v1"        | "name@host/v2:2" | "host/v2:2"
+        "host/v1:1"      | "name@host/v2:2" | "host/v2:2"
+        "host:port/v1"   | "name@host/v2:2" | "host/v2:2"
+        "host:port/v1:1" | "name@host/v2:2" | "host/v2:2"
+        "v1"             | "name@host:port/v2:2" | "host:port/v2:2"
+        "v1:1"           | "name@host:port/v2:2" | "host:port/v2:2"
+        "host/v1"        | "name@host:port/v2:2" | "host:port/v2:2"
+        "host/v1:1"      | "name@host:port/v2:2" | "host:port/v2:2"
+        "host:port/v1"   | "name@host:port/v2:2" | "host:port/v2:2"
+        "host:port/v1:1" | "name@host:port/v2:2" | "host:port/v2:2"
     }
 
     def 'can add entire directories via copyspec'() {

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -285,7 +285,7 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         """.stripIndent()
 
         when:
-        BuildResult buildResult = with('dockerTag', "--stacktrace").build()
+        BuildResult buildResult = with('dockerTag').build()
 
         then:
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS


### PR DESCRIPTION
## Description
This PR make 'tags' more powerful, you can use new 'tag' DSL to give the tag a task name.
There are some samples:
```Groovy
docker {
    name 'fake-service-name'
    tag 'withTaskName', 'fake-service-name:2.0'
    tag 'newImageName', 'new-image:latest'
}
```
It will generate tag tasks with name `dockerTagWithTaskName` and `dockerTagNewImageName`, and push tasks with name `dockerPushWithTaskName` and `dockerPushNewImageName`.

With task name, we can build some diff name image of one image, push to diff repo host.

## Note
'tags' DSL can resolve the tag name auto, but 'tag' can not. It means you must specify the image name for 'tag' DSL.  

There are some sample:
**Tag with just new version:**
name: `old-name:test`
tags dsl: `tags 'latest'`
tag dsl: `tag 'latest', 'docker-name:latest'`
image `result name: docker-name:latest`

**Tag with new name:**
name: `old-name:test`
tags dsl: `tags 'newName@docker-name:latest'`
tag dsl: `tag 'newName', 'docker-name:latest'`
image `result name: docker-name:latest`

**Tag with new repo host:**
name: `old-name:test`
tag: `newName@host:port/repo/docker-name:latest`
tags: `newName', 'host:port/repo/docker-name:latest'`
image result name: `host:port/repo/docker-name:latest`

>**Note:**
>Notice that tag must have a task name if you want to replace the repo or image name for 'tags' DSL

## New tasks
**dockerTagsPush**
Pushes all tagged Docker images to configured Docker Hub.
```
dockerTagsPush= dockerPush<Tag1>+ dockerPush<Tag2> + ... + dockerPush<Tagn>
```

**dockerAllPush**
Pushes all tagged Docker images and named Docker image to configured Docker Hub.
```
dockerAllPush = dockerTagsPush + dockerPush
```

## Solved issues
#195 Allow dockerPush to target multiple repositories
Use `dockerPush<Tag>` to diff repositories
```Groovy
docker {
    name 'repository1.foo.com/bar:lastest'
    tag 'repository2', 'repository2.foo.com/bar:lastest'
}
```
Run this command:
```Shell
./gradle dockerPushRepository2
```

#181 Pushing just the defined tags
Use `dockerTagsPush` task can solve this issue
```Groovy
docker {
    name 'repository1.foo.com/bar:lastest'
    tag 'tag1', 'bar:v1'
    tag 'tag2', 'bar:v2'
}
```
Run this command:
```Shell
./gradle dockerTagsPush
```

#95 Make push task depend on push tasks for each tag if tags are present
Use `dockerTagsPush` and `dockerPush` can solve this issue/PR without change behavior of `dockerPush`
```Groovy
docker {
    name 'repository1.foo.com/bar:lastest'
    tag 'tag1', 'bar:v1'
    tag 'tag2', 'bar:v2'
}
```
Run this command:
```Shell
./gradle dockerPush
./gradle dockerTagsPush
```

#149 dockerPush doesn't generate (and thus push) all Tags
#94 Ability to easily push all tags for an image
#209 Docker tag should support full retagging

## Test sample
There are some sample which used in test:

name | tag | result
------------ | ------------- | -------------
v1 | latest | v1:latest
v1:1 | latest | v1:latest
host/v1 | latest | host/v1:latest
host/v1:1 | latest | host/v1:latest
host:port/v1 | latest | host:port/v1:latest
host:port/v1:1 | latest | host:port/v1:latest
v1 | name@latest | v1:latest
v1:1 | name@latest | v1:latest
host/v1 | name@latest | host/v1:latest
host/v1:1 | name@latest | host/v1:latest
host:port/v1 | name@latest | host:port/v1:latest
host:port/v1:1 | name@latest | host:port/v1:latest
v1 | name@v2:latest | v2:latest
v1:1 | name@v2:latest | v2:latest
host/v1 | name@v2:latest | v2:latest
host/v1:1 | name@v2:latest | v2:latest
host:port/v1 | name@v2:latest | v2:latest
host:port/v1:1 | name@v2:latest | v2:latest
v1 | name@host/v2 | host/v2
v1:1 | name@host/v2 | host/v2
host/v1 | name@host/v2 | host/v2
host/v1:1 | name@host/v2 | host/v2
host:port/v1 | name@host/v2 | host/v2
host:port/v1:1 | name@host/v2 | host/v2
v1 | name@host/v2:2 | host/v2:2
v1:1 | name@host/v2:2 | host/v2:2
host/v1 | name@host/v2:2 | host/v2:2
host/v1:1 | name@host/v2:2 | host/v2:2
host:port/v1 | name@host/v2:2 | host/v2:2
host:port/v1:1 | name@host/v2:2 | host/v2:2
v1 | name@host:port/v2:2 | host:port/v2:2
v1:1 | name@host:port/v2:2 | host:port/v2:2
host/v1 | name@host:port/v2:2 | host:port/v2:2
host/v1:1 | name@host:port/v2:2 | host:port/v2:2
host:port/v1 | name@host:port/v2:2 | host:port/v2:2
host:port/v1:1 | name@host:port/v2:2 | host:port/v2:2