### PR TITLE
Add support for setting 'target' on docker plugin extension (with tests)

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -37,6 +37,7 @@ class DockerExtension {
     private Map<String, String> buildArgs = ImmutableMap.of()
     private boolean pull = false
     private boolean noCache = false
+    private String target = null
 
     private File resolvedDockerfile = null
     private File resolvedDockerComposeTemplate = null
@@ -149,5 +150,13 @@ class DockerExtension {
 
     public void noCache(boolean noCache) {
         this.noCache = noCache
+    }
+
+    public String getTarget() {
+        return target
+    }
+
+    public void target(String target) {
+        this.target = target
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -176,6 +176,10 @@ class PalantirDockerPlugin implements Plugin<Project> {
         if (ext.pull) {
             buildCommandLine.add '--pull'
         }
+        if (ext.target != null && ext.target != "") {
+            buildCommandLine.add '--target'
+            buildCommandLine.add ext.target
+        }
         buildCommandLine.addAll(['-t', "${ -> ext.name}", '.'])
         return buildCommandLine
     }


### PR DESCRIPTION
To support the --target parameter for multi-stage docker builds, add a 'target' setting to the docker extension, and add the appropriate command line parameter when building. Included test.