### PR TITLE
dockerRemoveContainer must run after dockerStop

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -136,6 +136,7 @@ class DockerRunPlugin implements Plugin<Project> {
 
             dockerRemoveContainer.with {
                 commandLine 'docker', 'rm', ext.name
+                mustRunAfter dockerStop
             }
         }
     }


### PR DESCRIPTION
[d.txt](https://github.com/palantir/gradle-docker/files/2524791/d.txt)
