### PR TITLE
print docker output to console with default LogLevel.LIFECYCLE (fixes #216)

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -115,7 +115,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
                 workingDir dockerDir
                 commandLine buildCommandLine(ext)
                 dependsOn ext.getDependencies()
-                logging.captureStandardOutput LogLevel.INFO
+                logging.captureStandardOutput LogLevel.LIFECYCLE
                 logging.captureStandardError LogLevel.ERROR
             }
 


### PR DESCRIPTION
#216 
