### PR TITLE
dependsOn build

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ Configuration specifying all parameters:
 
 ```gradle
 docker {
+    dependsOn build
     name 'hub.docker.com/username/my-app:version'
     tags 'latest' // deprecated, use 'tag'
     tag 'myRegistry', 'my.registry.com/username/my-app:version'


### PR DESCRIPTION
I am a starter of Gradle,if I clean(means It's don't hava a file of jar),run the gradle task  `gradle docker` ,it doesn't work well beacause not found jar file.

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->
ADD failed: stat /var/lib/docker/tmp/docker-builder940079280/JarFileName.jar: no such file or directory
`
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task :projectName:docker.
Process 'command 'docker'' finished with non-zero exit value 1

`
## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
