### PR TITLE
[improvement] docker configuration includes productDependencies

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
@@ -41,6 +41,9 @@ class DockerComposePlugin implements Plugin<Project> {
                 )))
             })
         })
+        project.getPlugins().withId("com.palantir.product-dependency-introspection", {
+            dockerConfiguration.extendsFrom(project.configurations.getByName('productDependencies'))
+        })
 
         project.tasks.create('generateDockerCompose', GenerateDockerCompose, {
             it.ext = ext

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
@@ -15,6 +15,7 @@
  */
 package com.palantir.gradle.docker
 
+import com.google.common.collect.ImmutableMap
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -25,6 +26,21 @@ class DockerComposePlugin implements Plugin<Project> {
         DockerComposeExtension ext =
             project.extensions.create('dockerCompose', DockerComposeExtension, project)
         Configuration dockerConfiguration = project.configurations.maybeCreate('docker')
+
+        // sls-packaging adds a 'productDependencies' configuration, which contains the inferred lower bounds of products
+        // you depend on.  We wire it up automatically, so all users don't need to add:
+        //
+        //    dependencies {
+        //        docker project(path: ':foo', configuration: 'productDependencies')
+        //    }
+        project.subprojects({ Project subproject ->
+            subproject.getPlugins().withId("com.palantir.product-dependency-introspection", {
+                dockerConfiguration.dependencies.add(subproject.dependencies.project(ImmutableMap.of(
+                        "path", subproject.path,
+                        "configuration", "productDependencies"
+                )))
+            })
+        })
 
         project.tasks.create('generateDockerCompose', GenerateDockerCompose, {
             it.ext = ext

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -15,7 +15,6 @@
  */
 package com.palantir.gradle.docker
 
-import com.google.common.collect.ImmutableMap
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -32,8 +31,6 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.bundling.Zip
-import org.gradle.internal.logging.text.StyledTextOutput
-import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 import javax.inject.Inject
 import java.util.regex.Pattern

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -104,21 +104,6 @@ class PalantirDockerPlugin implements Plugin<Project> {
         project.getComponents().add(new DockerComponent(dockerArtifact, dockerConfiguration.getAllDependencies(),
                 objectFactory, attributesFactory))
 
-        // sls-packaging adds a 'productDependencies' configuration, which contains the inferred lower bounds of products
-        // you depend on.  We wire it up automatically, so all users don't need to add:
-        //
-        //    dependencies {
-        //        docker project(path: ':foo', configuration: 'productDependencies')
-        //    }
-        project.subprojects({ Project subproject ->
-            subproject.getPlugins().withId("com.palantir.product-dependency-introspection", {
-                dockerConfiguration.dependencies.add(subproject.dependencies.project(ImmutableMap.of(
-                        "path", subproject.path,
-                        "configuration", "productDependencies"
-                )))
-            })
-        })
-
         project.afterEvaluate {
             ext.resolvePathsAndValidate()
             String dockerDir = "${project.buildDir}/docker"


### PR DESCRIPTION
## Before this PR

Internally, many repos use this plugin in conjunction with gradle-sls-packaging.  When trying to create a docker-compose.yml for ETE testing, users usually want to use versions of their _product dependencies_.

From [sls-packaging 3.7.1](https://github.com/palantir/sls-packaging/releases/tag/3.7.1) onwards, there's now a convenient way of getting access to this information.

## After this PR

Repos that use `com.palantir.docker-compose` at the root and `com.palantir.sls-java-service-distribution` in a subproject will now be able to magically refer to their product dependencies when templating their docker-compose.yml files:

```yml
 my-product:
    container_name: my-product.palantir.pt
    hostname: my-product
    domainname: palantir.pt
    image: 'docker-registry/foo/my-product:{{com.palantir.foo:my-product}}'
    ports:
      - "8901:8901"
      - "8902:8902"
```