### PR TITLE
[fix] generateDockerCompose re-runs if template tokens change

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
@@ -30,7 +30,7 @@ class GenerateDockerCompose extends DefaultTask {
             [("{{${it.group}:${it.name}}}"): it.version]
         }
 
-        templateTokens.putAll(ext.templateTokens.collectEntries {
+        templateTokens.putAll(extraTemplateTokens.collectEntries {
             [("{{${it.key}}}"): it.value]
         })
 
@@ -57,6 +57,11 @@ class GenerateDockerCompose extends DefaultTask {
             *.moduleVersion
             *.id
             .toSet()
+    }
+    
+    @Input
+    Map<String, String> getExtraTemplateTokens() {
+        return ext.templateTokens
     }
 
     @InputFiles


### PR DESCRIPTION
Fixes #226 

Allows regenerating files when the template tokens change.

Still needs test

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

## After this PR
<!-- Describe at a high-level why this approach is better. -->

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
