### PR TITLE
[fix] Don't shadow the standard gradle 'ext' field on tasks.

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
@@ -23,8 +23,7 @@ import org.gradle.api.artifacts.Configuration
 class DockerComposePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        DockerComposeExtension ext =
-            project.extensions.create('dockerCompose', DockerComposeExtension, project)
+        project.extensions.create('dockerCompose', DockerComposeExtension, project)
         Configuration dockerConfiguration = project.configurations.maybeCreate('docker')
 
         // sls-packaging adds a 'productDependencies' configuration, which contains the inferred lower bounds of products
@@ -46,12 +45,10 @@ class DockerComposePlugin implements Plugin<Project> {
         })
 
         project.tasks.create('generateDockerCompose', GenerateDockerCompose, {
-            it.ext = ext
             it.configuration = dockerConfiguration
         })
 
         project.tasks.create('dockerComposeUp', DockerComposeUp, {
-            it.ext = ext
             it.configuration = dockerConfiguration
         })
     }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeUp.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeUp.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.tasks.TaskAction
 
 @Slf4j
 class DockerComposeUp extends DefaultTask {
-    DockerComposeExtension ext
     Configuration configuration
 
     DockerComposeUp() {
@@ -25,12 +24,16 @@ class DockerComposeUp extends DefaultTask {
 
     @Override
     String getDescription() {
-        def defaultDescription = "Executes `docker-compose` using ${ext.dockerComposeFile.name}"
+        def defaultDescription = "Executes `docker-compose` using ${dockerComposeFile.name}"
         return super.description ?: defaultDescription
     }
 
     @InputFiles
     File getDockerComposeFile() {
-        return ext.dockerComposeFile
+        return dockerComposeExtension.dockerComposeFile
+    }
+
+    DockerComposeExtension getDockerComposeExtension() {
+        return project.extensions.findByType(DockerComposeExtension)
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/GenerateDockerCompose.groovy
@@ -14,7 +14,6 @@ import org.gradle.api.tasks.TaskAction
 @Slf4j
 class GenerateDockerCompose extends DefaultTask {
 
-    DockerComposeExtension ext
     Configuration configuration
 
     GenerateDockerCompose() {
@@ -30,7 +29,7 @@ class GenerateDockerCompose extends DefaultTask {
             [("{{${it.group}:${it.name}}}"): it.version]
         }
 
-        templateTokens.putAll(ext.templateTokens.collectEntries {
+        templateTokens.putAll(dockerComposeExtension.templateTokens.collectEntries {
             [("{{${it.key}}}"): it.value]
         })
 
@@ -43,7 +42,7 @@ class GenerateDockerCompose extends DefaultTask {
 
     @Override
     String getDescription() {
-        def defaultDescription = "Populates ${ext.template.name} file with versions" +
+        def defaultDescription = "Populates ${dockerComposeExtension.template.name} file with versions" +
                 " of dependencies from the '${configuration.name}' configuration"
         return super.description ?: defaultDescription
     }
@@ -61,12 +60,16 @@ class GenerateDockerCompose extends DefaultTask {
 
     @InputFiles
     File getTemplate() {
-        return ext.template
+        return dockerComposeExtension.template
     }
 
     @OutputFile
     File getDockerComposeFile() {
-        return ext.dockerComposeFile
+        return dockerComposeExtension.dockerComposeFile
+    }
+
+    DockerComposeExtension getDockerComposeExtension() {
+        return project.extensions.findByType(DockerComposeExtension)
     }
 
     /** Replaces all occurrences of templatesTokens's keys by their corresponding values in the given line. */

--- a/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
@@ -201,4 +201,23 @@ class DockerComposePluginTests extends AbstractPluginTest {
         then:
         file("qux").exists()
     }
+
+    def 'can set custom properties on generateDockerCompose.ext'() {
+        given:
+        file('docker-compose.yml.template') << '''
+            version: "2"
+            services: {}
+        '''.stripIndent()
+        buildFile << '''
+            plugins {
+                id 'com.palantir.docker-compose'
+            }
+
+            generateDockerCompose.ext.foo = "bar"
+        '''.stripIndent()
+        when:
+        BuildResult buildResult = with('generateDockerCompose').build()
+        then:
+        buildResult.task(':generateDockerCompose').outcome == TaskOutcome.SUCCESS
+    }
 }


### PR DESCRIPTION
[fix] All Gradle Tasks (and many other things) have a special 'ext' extension,
which is of type ExtraPropertiesExtension
(see https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/ExtensionAware.html).
Previously the DockerComposeExtension was shadowing this as it was set as a field
with name 'ext' on the gradle tasks created by this plugin.

## Before this PR

It was not possible to set custom properties on the `generateDockerCompose` task by the usual `generateDockerCompose.ext.foo = "bar"` method supported by all other Gradle tasks because the `GenerateDockerCompose` task had a field `ext` that contained the `DockerComposeExtension`.

## After this PR

This PR removes the `ext` field on `GenerateDockerCompose` and `DockerComposeUp` and gets the `DockerComposeExtension` directly from the project.
