### PR TITLE
[improvement] Add support for --init as init property to dockerRun extension

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,7 @@ dockerRun {
     daemonize true
     env 'MYVAR1': 'MYVALUE1', 'MYVAR2': 'MYVALUE2'
     command 'sleep', '100'
+    init true
 }
 ```
 
@@ -258,6 +259,8 @@ dockerRun {
 - `clean` (optional) a boolean argument which adds `--rm` to the `docker run`
   command to ensure that containers are cleaned up after running; defaults to `false`
 - `command` the command to run.
+- `init` Run an init inside the container that forwards signals and reaps processes;
+  defaults to `false`
 
 Tasks
 -----

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -33,6 +33,7 @@ class DockerRunExtension {
     private Map<Object,String> volumes = ImmutableMap.of()
     private boolean daemonize = true
     private boolean clean = false
+	private boolean init = false
 
     public String getName() {
         return name
@@ -49,13 +50,21 @@ class DockerRunExtension {
     public void setDaemonize(boolean daemonize) {
         this.daemonize = daemonize
     }
+	
+	public boolean getClean() {
+		return clean
+	}
 
-    public boolean getClean() {
-        return clean
+	public void setClean(boolean clean) {
+		this.clean = clean
+	}
+	
+    public boolean getInit() {
+        return init
     }
 
-    public void setClean(boolean clean) {
-        this.clean = clean
+    public void setInit(boolean init) {
+        this.init = init
     }
 
     public String getImage() {

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -98,6 +98,9 @@ class DockerRunPlugin implements Plugin<Project> {
                 if (ext.daemonize) {
                   args.add('-d')
                 }
+				if (ext.init) {
+					args.add('--init')
+				}
                 if (ext.clean) {
                   args.add('--rm')
                 } else {


### PR DESCRIPTION
## Before this PR
The dockerRun plugin does a lot of what I need, but it does not have support for the --init flag.
The --init flag is necessary for processes to properly be terminated and reaped, as per the docker run man page:
```
--init
          Run an init inside the container that forwards signals and reaps processes
```

## After this PR
Now the dockerRun extension has a new boolean property `init`, default to false, but when set to true, `--init` is passed into the resulting `docker run` command.

A test has been included to verify the functionality.