### PR TITLE
[improvement] Add support for workdir (-w, --workdir)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,7 @@ dockerRun {
     daemonize true
     env 'MYVAR1': 'MYVALUE1', 'MYVAR2': 'MYVALUE2'
     command 'sleep', '100'
+    workdir '/containervolume'
 }
 ```
 
@@ -258,6 +259,7 @@ dockerRun {
 - `clean` (optional) a boolean argument which adds `--rm` to the `docker run`
   command to ensure that containers are cleaned up after running; defaults to `false`
 - `command` the command to run.
+- `workdir` the working directory inside the container; defaults to '/'.
 
 Tasks
 -----

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -27,6 +27,7 @@ class DockerRunExtension {
     private String name
     private String image
     private String network
+    private String workdir
     private List<String> command = ImmutableList.of()
     private Set<String> ports = ImmutableSet.of()
     private Map<String,String> env = ImmutableMap.of()
@@ -41,6 +42,14 @@ class DockerRunExtension {
     public void setName(String name) {
         this.name = name
     }
+	
+	public String getWorkdir() {
+		return workdir
+	}
+
+	public void setWorkdir(String workdir) {
+		this.workdir = workdir
+	}
 
     public boolean getDaemonize() {
         return daemonize

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -110,6 +110,9 @@ class DockerRunPlugin implements Plugin<Project> {
                     args.add('-p')
                     args.add(port)
                 }
+				if (ext.workdir) {
+					args.addAll(['-w', ext.workdir])
+				}
                 for (Entry<Object,String> volume : ext.volumes.entrySet()) {
                     File localFile = project.file(volume.key)
 


### PR DESCRIPTION
## Before this PR
There is currently no way to set the -w, --workdir from the dockerRun plugin.

Per the docker run man page:
```
Working directory inside the container
```

## After this PR
Now the working directory can be set with the syntax:
```
dockerRun {
     workdir '/dir'
}
```
Which will be where the dockerRun.command is executed.

This PR also includes a test for the functionality.