### PR TITLE
[improvement] Allow setting additional docker run args with arguments property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,7 @@ dockerRun {
     daemonize true
     env 'MYVAR1': 'MYVALUE1', 'MYVAR2': 'MYVALUE2'
     command 'sleep', '100'
+    arguments '--hostname=custom', '-P'
 }
 ```
 
@@ -258,7 +259,9 @@ dockerRun {
 - `clean` (optional) a boolean argument which adds `--rm` to the `docker run`
   command to ensure that containers are cleaned up after running; defaults to `false`
 - `command` the command to run.
-
+- `arguments` additional arguments to be passed into the docker run command.
+   Please see https://docs.docker.com/engine/reference/run/ for possible values.
+   
 Tasks
 -----
 

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -102,14 +102,14 @@ class DockerRunExtension {
     public Map<String, String> getEnv() {
         return env
     }
-	
-	public void arguments(String... arguments) {
-		this.arguments = ImmutableList.copyOf(arguments)
-	}
-	
-	public List<String> getArguments() {
-		return arguments
-	}
+
+    public void arguments(String... arguments) {
+        this.arguments = ImmutableList.copyOf(arguments)
+    }
+
+    public List<String> getArguments() {
+        return arguments
+    }
 
     public void ports(String... ports) {
         ImmutableSet.Builder builder = ImmutableSet.builder()

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -94,7 +94,7 @@ class DockerRunExtension {
     private void setEnvSingle(String key, String value) {
         this.env.put(checkNotNull(key, "key"), checkNotNull(value, "value"))
     }
-	
+
     public void env(Map<String,String> env) {
         this.env = ImmutableMap.copyOf(env)
     }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -30,6 +30,7 @@ class DockerRunExtension {
     private List<String> command = ImmutableList.of()
     private Set<String> ports = ImmutableSet.of()
     private Map<String,String> env = ImmutableMap.of()
+    private List<String> arguments = ImmutableList.of()
     private Map<Object,String> volumes = ImmutableMap.of()
     private boolean daemonize = true
     private boolean clean = false
@@ -93,14 +94,22 @@ class DockerRunExtension {
     private void setEnvSingle(String key, String value) {
         this.env.put(checkNotNull(key, "key"), checkNotNull(value, "value"))
     }
-
-    public void env(Map<String,String> env) {
-        this.env = ImmutableMap.copyOf(env)
-    }
+	
+	public void env(Map<String,String> env) {
+		this.env = ImmutableMap.copyOf(env)
+	}
 
     public Map<String, String> getEnv() {
         return env
     }
+	
+	public void arguments(String... arguments) {
+		this.arguments = ImmutableList.copyOf(arguments)
+	}
+	
+	public List<String> getArguments() {
+		return arguments
+	}
 
     public void ports(String... ports) {
         ImmutableSet.Builder builder = ImmutableSet.builder()

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -95,9 +95,9 @@ class DockerRunExtension {
         this.env.put(checkNotNull(key, "key"), checkNotNull(value, "value"))
     }
 	
-	public void env(Map<String,String> env) {
-		this.env = ImmutableMap.copyOf(env)
-	}
+    public void env(Map<String,String> env) {
+        this.env = ImmutableMap.copyOf(env)
+    }
 
     public Map<String, String> getEnv() {
         return env

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -123,7 +123,10 @@ class DockerRunPlugin implements Plugin<Project> {
                     args.add("${localFile.absolutePath}:${volume.value}")
                 }
                 args.addAll(ext.env.collect{ k, v -> ['-e', "${k}=${v}"] }.flatten())
-                args.addAll(['--name', ext.name, ext.image])
+				for (String argument : ext.arguments) {
+					args.add(argument)
+				}
+				args.addAll(['--name', ext.name, ext.image])
                 if (!ext.command.isEmpty()) {
                     args.addAll(ext.command)
                 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -123,10 +123,12 @@ class DockerRunPlugin implements Plugin<Project> {
                     args.add("${localFile.absolutePath}:${volume.value}")
                 }
                 args.addAll(ext.env.collect{ k, v -> ['-e', "${k}=${v}"] }.flatten())
-				for (String argument : ext.arguments) {
-					args.add(argument)
-				}
-				args.addAll(['--name', ext.name, ext.image])
+                args.add('--name')
+                args.add(ext.name)
+                if (!ext.arguments.isEmpty()) {
+                    args.addAll(ext.arguments)
+                }
+                args.add(ext.image)
                 if (!ext.command.isEmpty()) {
                     args.addAll(ext.command)
                 }

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -153,6 +153,42 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar-nodaemonize' is STOPPED./
     }
+	
+	def 'can set additional arguments'() {
+	   given:
+	   file('Dockerfile') << '''
+            FROM alpine:3.2
+             RUN mkdir /test
+        '''.stripIndent()
+	   buildFile << '''
+            plugins {
+                id 'com.palantir.docker'
+                id 'com.palantir.docker-run'
+            }
+             docker {
+                name 'foo-image:latest'
+            }
+             dockerRun {
+                name 'foo'
+                image 'foo-image:latest'
+                arguments '-w=/test'
+                daemonize false
+				command 'pwd'
+            }
+        '''.stripIndent()
+
+		when:
+	   BuildResult buildResult = with('docker', 'dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
+
+		then:
+	   buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+
+		buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+	   buildResult.output =~ /(?m)\/test/
+
+		buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+	   buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
+   }
 
     def 'can mount volumes'() {
         if (isCi()) {

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -153,42 +153,42 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar-nodaemonize' is STOPPED./
     }
-	
-	def 'can set additional arguments'() {
-	   given:
-	   file('Dockerfile') << '''
-            FROM alpine:3.2
-             RUN mkdir /test
-        '''.stripIndent()
-	   buildFile << '''
-            plugins {
-                id 'com.palantir.docker'
-                id 'com.palantir.docker-run'
-            }
-             docker {
-                name 'foo-image:latest'
-            }
-             dockerRun {
-                name 'foo'
-                image 'foo-image:latest'
-                arguments '-w=/test'
-                daemonize false
-				command 'pwd'
-            }
-        '''.stripIndent()
 
-		when:
-	   BuildResult buildResult = with('docker', 'dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
+    def 'can set additional arguments'() {
+        given:
+        file('Dockerfile') << '''
+                FROM alpine:3.2
+                 RUN mkdir /test
+          '''.stripIndent()
+        buildFile << '''
+                plugins {
+                     id 'com.palantir.docker'
+                     id 'com.palantir.docker-run'
+                }
+                 docker {
+                     name 'foo-image:latest'
+                }
+                 dockerRun {
+                     name 'foo'
+                     image 'foo-image:latest'
+                     arguments '-w=/test'
+                     daemonize false
+                command 'pwd'
+                }
+          '''.stripIndent()
 
-		then:
-	   buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
+        when:
+        BuildResult buildResult = with('docker', 'dockerRemoveContainer', 'dockerRun', 'dockerRunStatus').build()
 
-		buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
-	   buildResult.output =~ /(?m)\/test/
+        then:
+        buildResult.task(':dockerRemoveContainer').outcome == TaskOutcome.SUCCESS
 
-		buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-	   buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
-   }
+        buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
+        buildResult.output =~ /(?m)\/test/
+
+        buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
+        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
+    }
 
     def 'can mount volumes'() {
         if (isCi()) {


### PR DESCRIPTION
## Before this PR
dockerRun is a very useful plugin, but it has limitations on how it can be used, specifically in regard to unsupported arguments.

## After this PR
This PR adds an extension property to dockerRun to allow setting custom arguments for docker run, in this form:
```
dockerRun {
    arguments '-P', 'w=/test'
}
```
This PR also includes a test for this functionality.