### PR TITLE
Allowing multiple Tasks of same type dockerRun

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ if (System.env.CIRCLE_TEST_REPORTS) {
 group 'com.palantir.gradle.docker'
 version System.env.CIRCLE_TAG ?: gitVersion()
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource

--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,7 @@ dockerRun {
     name 'my-container'
     image 'busybox'
     volumes 'hostvolume': '/containervolume'
+    network 'host'
     ports '7080:5000'
     daemonize true
     env 'MYVAR1': 'MYVALUE1', 'MYVAR2': 'MYVALUE2'
@@ -251,17 +252,50 @@ dockerRun {
 **Docker Run Configuration Parameters**
 - `name` the name to use for this container, may include a tag.
 - `image` the name of the image to use.
-- `volumes` optional map of volumes to mount in the container. The key is the path
+- `volumes` (optional) map of volumes to mount in the container. The key is the path
   to the host volume, resolved using [`project.file()`](https://docs.gradle.org/current/userguide/working_with_files.html#sec:locating_files).
   The value is the exposed container volume path.
-- `ports` optional mapping `local:container` of local port to container port.
-- `env` optional map of environment variables to supply to the running container.
+- `ports` (optional) mapping `local:container` of local port to container port.
+- `env` (optional) map of environment variables to supply to the running container.
   These must be exposed in the Dockerfile with `ENV` instructions.
-- `daemonize` defaults to true to daemonize the container after starting. However
+- `network` (optional) Connect a container to a network.
+- `daemonize` (optional) defaults to `true` to daemonize the container after starting. However
   if your container runs a command and exits, you can set this to false.
 - `clean` (optional) a boolean argument which adds `--rm` to the `docker run`
   command to ensure that containers are cleaned up after running; defaults to `false`
-- `command` the command to run.
+- `command` (optional) the command to run.
+
+**Docker Run custom Tasks**
+Use the DockerRunTaskTypes to configure custom Tasks:
+
+```gradle
+task runA(type: DockerRun){
+    name 'container-A'
+    image 'busybox'
+    command 'sleep', '10'
+}
+
+task runB(type: DockerRun){
+    name 'container-B'
+    image 'busybox'
+    command 'sleep', '10'
+}
+
+task stopA(type: DockerStop){
+    name 'container-A'
+}
+
+task stopB(type: DockerStop){
+    name 'container-B'
+}
+```
+The custom DockerRunTaskTypes are:
+- `DockerRun` uses all parameters from `dockerRun` unless overridden
+- `DockerStop` uses `name` from `dockerRun` unless overridden
+- `DockerRunStatus` uses `name` from `dockerRun` unless overridden
+- `dockerRemoveContainer` uses `name` from `dockerRun` unless overridden
+- `DockerNetworkModeStatus` uses `name` and `network` from `dockerRun` unless overridden
+
 
 Tasks
 -----
@@ -288,7 +322,7 @@ Tasks
    * `dockerStop`: stop the running container
    * `dockerRunStatus`: indicate the run status of the container
    * `dockerRemoveContainer`: remove the container
-
+   * `DockerNetworkModeStatus`: checks the network configuration of the container
 License
 -------
 This plugin is made available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -19,87 +19,67 @@ import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
-
-import static com.google.common.base.Preconditions.checkNotNull
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
 
 class DockerRunExtension {
 
-    private String name
-    private String image
-    private String network
-    private List<String> command = ImmutableList.of()
-    private Set<String> ports = ImmutableSet.of()
-    private Map<String,String> env = ImmutableMap.of()
-    private Map<Object,String> volumes = ImmutableMap.of()
-    private boolean daemonize = true
-    private boolean clean = false
+    Property<String> name
+    Property<String> image
+    Property<String> network
+    Property<List<String>> command
+    Property<Set<String>> ports
+    Property<Map<String, String>> env
+    Property<Map<Object, String>> volumes
+    Property<Boolean> daemonize
+    Property<Boolean> clean
 
-    public String getName() {
-        return name
+    DockerRunExtension(Project project) {
+        name = project.objects.property(String)
+        image = project.objects.property(String)
+        network = project.objects.property(String)
+        command = project.objects.property(List)
+        ports = project.objects.property(Set)
+        env = project.objects.property(Map)
+        volumes = project.objects.property(Map)
+        daemonize = project.objects.property(Boolean)
+        clean = project.objects.property(Boolean)
+
+        command.set(ImmutableList.of())
+        ports.set(ImmutableSet.of())
+        env.set(ImmutableMap.of())
+        volumes.set(ImmutableMap.of())
+
+        daemonize.set(true)
+        clean.set(false)
     }
 
     public void setName(String name) {
-        this.name = name
-    }
-
-    public boolean getDaemonize() {
-        return daemonize
+        this.name.set name
     }
 
     public void setDaemonize(boolean daemonize) {
-        this.daemonize = daemonize
-    }
-
-    public boolean getClean() {
-        return clean
+        this.daemonize.set daemonize
     }
 
     public void setClean(boolean clean) {
-        this.clean = clean
-    }
-
-    public String getImage() {
-        return image
+        this.clean.set clean
     }
 
     public void setImage(String image) {
-        this.image = image
-    }
-
-    public Set<String> getPorts() {
-        return ports
-    }
-
-    public List<String> getCommand() {
-        return command
-    }
-
-    public Map<Object,String> getVolumes() {
-        return volumes
+        this.image.set image
     }
 
     public void command(String... command) {
-        this.command = ImmutableList.copyOf(command)
+        this.command.set ImmutableList.copyOf(command)
     }
 
     public void setNetwork(String network) {
-        this.network = network
+        this.network.set network
     }
 
-    public String getNetwork() {
-        return network
-    }
-
-    private void setEnvSingle(String key, String value) {
-        this.env.put(checkNotNull(key, "key"), checkNotNull(value, "value"))
-    }
-
-    public void env(Map<String,String> env) {
-        this.env = ImmutableMap.copyOf(env)
-    }
-
-    public Map<String, String> getEnv() {
-        return env
+    public void env(Map<String, String> env) {
+        this.env.set ImmutableMap.copyOf(env)
     }
 
     public void ports(String... ports) {
@@ -115,11 +95,11 @@ class DockerRunExtension {
                 builder.add("${mapping[0]}:${mapping[1]}")
             }
         }
-        this.ports = builder.build()
+        this.ports.set builder.build()
     }
 
-    public void volumes(Map<Object,String> volumes) {
-      this.volumes = ImmutableMap.copyOf(volumes)
+    public void volumes(Map<Object, String> volumes) {
+        this.volumes.set ImmutableMap.copyOf(volumes)
     }
 
     private static void checkPortIsValid(String port) {

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -15,40 +15,29 @@
  */
 package com.palantir.gradle.docker
 
-
+import com.palantir.gradle.docker.run.DockerNetworkModeStatus
+import com.palantir.gradle.docker.run.DockerRemoveContainer
+import com.palantir.gradle.docker.run.DockerRunStatus
+import com.palantir.gradle.docker.run.DockerRun
+import com.palantir.gradle.docker.run.DockerStop
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtraPropertiesExtension
-import org.gradle.api.tasks.Exec
 
 class DockerRunPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         DockerRunExtension ext = project.extensions.create('dockerRun', DockerRunExtension)
 
-        project.tasks.create('dockerRunStatus', Exec, {
-            group = 'Docker Run'
-            description = 'Checks the run status of the container'
-
-            project.afterEvaluate {
-                standardOutput = new ByteArrayOutputStream()
-                commandLine 'docker', 'inspect', '--format={{.State.Running}}', ext.name
-                doLast {
-                    if (standardOutput.toString().trim() != 'true') {
-                        println "Docker container '${ext.name}' is STOPPED."
-                        return 1
-                    } else {
-                        println "Docker container '${ext.name}' is RUNNING."
-                    }
-                }
-            }
-        })
-
-
         ExtraPropertiesExtension extraProperties = project.getExtensions().getExtraProperties();
-        extraProperties.set(DockerRunTask.class.getSimpleName(), DockerRunTask.class);
 
-        project.tasks.create('dockerRun', DockerRunTask.class) {
+        extraProperties.set(DockerRun.class.getSimpleName(), DockerRun.class);
+
+        project.tasks.create('dockerRunStatus', DockerRunStatus.class) {
+            conventionMapping.containerName = { project.dockerRun.name }
+        }
+
+        project.tasks.create('dockerRun', DockerRun.class) {
             conventionMapping.containerName = { project.dockerRun.name }
             conventionMapping.image = { project.dockerRun.image }
             conventionMapping.command = { project.dockerRun.command }
@@ -60,44 +49,17 @@ class DockerRunPlugin implements Plugin<Project> {
             conventionMapping.clean = { project.dockerRun.clean }
         }
 
-        project.tasks.create('dockerStop', Exec, {
-            group = 'Docker Run'
-            description = 'Stops the named container if it is running'
-            ignoreExitValue = true
-            project.afterEvaluate {
-                commandLine 'docker', 'stop', ext.name
-            }
-        })
+        project.tasks.create('dockerStop', DockerStop.class) {
+            conventionMapping.containerName = { project.dockerRun.name }
+        }
 
-        project.tasks.create('dockerRemoveContainer', Exec, {
-            group = 'Docker Run'
-            description = 'Removes the persistent container associated with the Docker Run tasks'
-            ignoreExitValue = true
-            project.afterEvaluate {
-                commandLine 'docker', 'rm', ext.name
-            }
-        })
+        project.tasks.create('dockerRemoveContainer', DockerRemoveContainer.class) {
+            conventionMapping.containerName = { project.dockerRun.name }
+        }
 
-        project.tasks.create('dockerNetworkModeStatus', Exec, {
-            group = 'Docker Run'
-            description = 'Checks the network configuration of the container'
-            project.afterEvaluate {
-                standardOutput = new ByteArrayOutputStream()
-                commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', ext.name
-                doLast {
-                    def networkMode = standardOutput.toString().trim()
-                    if (networkMode == 'default') {
-                        println "Docker container '${ext.name}' has default network configuration (bridge)."
-                    } else {
-                        if (networkMode == ext.network) {
-                            println "Docker container '${ext.name}' is configured to run with '${ext.network}' network mode."
-                        } else {
-                            println "Docker container '${ext.name}' runs with '${networkMode}' network mode instead of the configured '${ext.network}'."
-                            return 1
-                        }
-                    }
-                }
-            }
-        })
+        project.tasks.create('dockerNetworkModeStatus', DockerNetworkModeStatus.class){
+            conventionMapping.containerName = { project.dockerRun.name }
+            conventionMapping.network = { project.dockerRun.network }
+        }
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -15,11 +15,7 @@
  */
 package com.palantir.gradle.docker
 
-import com.palantir.gradle.docker.run.DockerNetworkModeStatus
-import com.palantir.gradle.docker.run.DockerRemoveContainer
-import com.palantir.gradle.docker.run.DockerRunStatus
-import com.palantir.gradle.docker.run.DockerRun
-import com.palantir.gradle.docker.run.DockerStop
+import com.palantir.gradle.docker.run.*
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtraPropertiesExtension
@@ -27,39 +23,20 @@ import org.gradle.api.plugins.ExtraPropertiesExtension
 class DockerRunPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        DockerRunExtension ext = project.extensions.create('dockerRun', DockerRunExtension)
+        DockerRunExtension ext = project.extensions.create('dockerRun', DockerRunExtension, project)
 
-        ExtraPropertiesExtension extraProperties = project.getExtensions().getExtraProperties();
+        ExtraPropertiesExtension extraProperties = project.getExtensions().getExtraProperties()
 
-        extraProperties.set(DockerRun.class.getSimpleName(), DockerRun.class);
+        extraProperties.set(DockerRun.class.getSimpleName(), DockerRun.class)
+        extraProperties.set(DockerRunStatus.class.getSimpleName(), DockerRunStatus.class)
+        extraProperties.set(DockerStop.class.getSimpleName(), DockerStop.class)
+        extraProperties.set(DockerRemoveContainer.class.getSimpleName(), DockerRemoveContainer.class)
+        extraProperties.set(DockerNetworkModeStatus.class.getSimpleName(), DockerNetworkModeStatus.class)
 
-        project.tasks.create('dockerRunStatus', DockerRunStatus.class) {
-            conventionMapping.containerName = { project.dockerRun.name }
-        }
-
-        project.tasks.create('dockerRun', DockerRun.class) {
-            conventionMapping.containerName = { project.dockerRun.name }
-            conventionMapping.image = { project.dockerRun.image }
-            conventionMapping.command = { project.dockerRun.command }
-            conventionMapping.network = { project.dockerRun.network }
-            conventionMapping.ports = { project.dockerRun.ports }
-            conventionMapping.env = { project.dockerRun.env }
-            conventionMapping.volumes = { project.dockerRun.volumes }
-            conventionMapping.daemonize = { project.dockerRun.daemonize }
-            conventionMapping.clean = { project.dockerRun.clean }
-        }
-
-        project.tasks.create('dockerStop', DockerStop.class) {
-            conventionMapping.containerName = { project.dockerRun.name }
-        }
-
-        project.tasks.create('dockerRemoveContainer', DockerRemoveContainer.class) {
-            conventionMapping.containerName = { project.dockerRun.name }
-        }
-
-        project.tasks.create('dockerNetworkModeStatus', DockerNetworkModeStatus.class){
-            conventionMapping.containerName = { project.dockerRun.name }
-            conventionMapping.network = { project.dockerRun.network }
-        }
+        project.tasks.create('dockerRun', DockerRun.class)
+        project.tasks.create('dockerStop', DockerStop.class)
+        project.tasks.create('dockerRemoveContainer', DockerRemoveContainer.class)
+        project.tasks.create('dockerNetworkModeStatus', DockerNetworkModeStatus.class)
+        project.tasks.create('dockerRunStatus', DockerRunStatus.class)
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunTask.groovy
@@ -1,16 +1,17 @@
 package com.palantir.gradle.docker
 
+import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
+import com.google.common.collect.Lists
 import org.gradle.api.tasks.AbstractExecTask
-
-import java.lang.reflect.Array
+import org.gradle.internal.logging.text.StyledTextOutput
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 class DockerRunTask extends AbstractExecTask {
 
-//    String name ='dockerRun'
-    String nameContainer
+    String containerName
     String image
     String network
     List<String> command = ImmutableList.of()
@@ -22,9 +23,106 @@ class DockerRunTask extends AbstractExecTask {
 
     DockerRunTask() {
         super(DockerRunTask.class)
+        group = 'Docker Run'
+        description = 'Runs the specified container with port mappings'
+        project.afterEvaluate {
+            List<String> args = Lists.newArrayList()
+            args.addAll(['docker', 'run'])
+            if (daemonize) {
+                args.add('-d')
+            }
+            if (clean) {
+                args.add('--rm')
+            } else {
+                finalizedBy project.tasks.dockerRunStatus
+            }
+            if (network) {
+                args.addAll(['--network', network])
+            }
+            for (String port : ports) {
+                args.add('-p')
+                args.add(port)
+            }
+            for (Map.Entry<Object, String> volume : volumes.entrySet()) {
+                File localFile = project.file(volume.key)
+
+                if (!localFile.exists()) {
+                    StyledTextOutput o = project.services.get(StyledTextOutputFactory.class).create(DockerRunPlugin)
+                    o.withStyle(StyledTextOutput.Style.Error).println("ERROR: Local folder ${localFile} doesn't exist. Mounted volume will not be visible to container")
+                    throw new IllegalStateException("Local folder ${localFile} doesn't exist.")
+                }
+
+                args.add('-v')
+                args.add("${localFile.absolutePath}:${volume.value}")
+            }
+            args.addAll(env.collect { k, v -> ['-e', "${k}=${v}"] }.flatten())
+            args.addAll(['--name', containerName, image])
+            if (!command.isEmpty()) {
+                args.addAll(command)
+            }
+            assert !args.contains(null)
+            commandLine args
+        }
     }
 
-    def command(String[] command){
+    def name(String name) {
+        this.containerName = name
+    }
+
+    def containerName(String containerName) {
+        this.containerName = containerName
+    }
+
+    def image(String image) {
+        this.image = image
+    }
+
+    def network(String network) {
+        this.network = network
+    }
+
+    def env(Map<String, String> env) {
+        this.env = env
+    }
+
+    def daemonize(boolean daemonize) {
+        this.daemonize = daemonize
+    }
+
+    def clean(boolean clean) {
+        this.clean = clean
+    }
+
+    def command(String[] command) {
         this.command = Arrays.asList(command)
+    }
+
+    def command(List<String> command) {
+        this.command = command
+    }
+
+    def ports(String... ports) {
+        ImmutableSet.Builder builder = ImmutableSet.<String> builder()
+        for (String port : ports) {
+            String[] mapping = port.split(':', 2)
+            if (mapping.length == 1) {
+                checkPortIsValid(mapping[0])
+                builder.add("${mapping[0]}:${mapping[0]}")
+            } else {
+                checkPortIsValid(mapping[0])
+                checkPortIsValid(mapping[1])
+                builder.add("${mapping[0]}:${mapping[1]}")
+            }
+        }
+        this.ports = builder.build()
+    }
+
+    private static void checkPortIsValid(String port) {
+        int val = Integer.parseInt(port)
+        Preconditions.checkArgument(0 < val && val <= 65536, "Port must be in the range [1,65536]")
+    }
+
+    def volumes(Map<Object, String> volumes) {
+        this.volumes = ImmutableMap.copyOf(volumes)
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunTask.groovy
@@ -1,0 +1,30 @@
+package com.palantir.gradle.docker
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import com.google.common.collect.ImmutableSet
+import org.gradle.api.tasks.AbstractExecTask
+
+import java.lang.reflect.Array
+
+class DockerRunTask extends AbstractExecTask {
+
+//    String name ='dockerRun'
+    String nameContainer
+    String image
+    String network
+    List<String> command = ImmutableList.of()
+    Set<String> ports = ImmutableSet.of()
+    Map<String, String> env = ImmutableMap.of()
+    Map<Object, String> volumes = ImmutableMap.of()
+    boolean daemonize = true
+    boolean clean = false
+
+    DockerRunTask() {
+        super(DockerRunTask.class)
+    }
+
+    def command(String[] command){
+        this.command = Arrays.asList(command)
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerNetworkModeStatus.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerNetworkModeStatus.groovy
@@ -9,18 +9,18 @@ class DockerNetworkModeStatus extends DockerRunBaseTask {
 
         project.afterEvaluate {
             standardOutput = new ByteArrayOutputStream()
-            commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', containerName.get()
+            commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', containerName.getOrNull()
         }
 
         doLast {
             def networkMode = standardOutput.toString().trim()
             if (networkMode == 'default') {
-                println "Docker container '${containerName.get()}' has default network configuration (bridge)."
+                println "Docker container '${containerName.getOrNull()}' has default network configuration (bridge)."
             } else {
                 if (networkMode == network.get()) {
-                    println "Docker container '${containerName.get()}' is configured to run with '${network.get()}' network mode."
+                    println "Docker container '${containerName.getOrNull()}' is configured to run with '${network.getOrNull()}' network mode."
                 } else {
-                    println "Docker container '${containerName.get()}' runs with '${networkMode}' network mode instead of the configured '${network.get()}'."
+                    println "Docker container '${containerName.getOrNull()}' runs with '${networkMode}' network mode instead of the configured '${network.getOrNull()}'."
                     return 1
                 }
             }

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerNetworkModeStatus.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerNetworkModeStatus.groovy
@@ -2,8 +2,6 @@ package com.palantir.gradle.docker.run
 
 class DockerNetworkModeStatus extends DockerRunBaseTask {
 
-    String network
-
     DockerNetworkModeStatus() {
         super(DockerNetworkModeStatus.class)
         group = 'Docker Run'
@@ -11,26 +9,22 @@ class DockerNetworkModeStatus extends DockerRunBaseTask {
 
         project.afterEvaluate {
             standardOutput = new ByteArrayOutputStream()
-            commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', containerName
+            commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', containerName.get()
         }
 
         doLast {
             def networkMode = standardOutput.toString().trim()
             if (networkMode == 'default') {
-                println "Docker container '${containerName}' has default network configuration (bridge)."
+                println "Docker container '${containerName.get()}' has default network configuration (bridge)."
             } else {
-                if (networkMode == network) {
-                    println "Docker container '${containerName}' is configured to run with '${network}' network mode."
+                if (networkMode == network.get()) {
+                    println "Docker container '${containerName.get()}' is configured to run with '${network.get()}' network mode."
                 } else {
-                    println "Docker container '${containerName}' runs with '${networkMode}' network mode instead of the configured '${network}'."
+                    println "Docker container '${containerName.get()}' runs with '${networkMode}' network mode instead of the configured '${network.get()}'."
                     return 1
                 }
             }
         }
 
-    }
-
-    def network(String network) {
-        this.network = network
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerNetworkModeStatus.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerNetworkModeStatus.groovy
@@ -1,0 +1,36 @@
+package com.palantir.gradle.docker.run
+
+class DockerNetworkModeStatus extends DockerRunBaseTask {
+
+    String network
+
+    DockerNetworkModeStatus() {
+        super(DockerNetworkModeStatus.class)
+        group = 'Docker Run'
+        description = 'Checks the network configuration of the container'
+
+        project.afterEvaluate {
+            standardOutput = new ByteArrayOutputStream()
+            commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', containerName
+        }
+
+        doLast {
+            def networkMode = standardOutput.toString().trim()
+            if (networkMode == 'default') {
+                println "Docker container '${containerName}' has default network configuration (bridge)."
+            } else {
+                if (networkMode == network) {
+                    println "Docker container '${containerName}' is configured to run with '${network}' network mode."
+                } else {
+                    println "Docker container '${containerName}' runs with '${networkMode}' network mode instead of the configured '${network}'."
+                    return 1
+                }
+            }
+        }
+
+    }
+
+    def network(String network) {
+        this.network = network
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRemoveContainer.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRemoveContainer.groovy
@@ -8,7 +8,7 @@ class DockerRemoveContainer extends DockerRunBaseTask {
         description = 'Removes the persistent container associated with the Docker Run tasks'
         ignoreExitValue = true
         project.afterEvaluate {
-            commandLine 'docker', 'rm', containerName.get()
+            commandLine 'docker', 'rm', containerName.getOrNull()
         }
     }
 

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRemoveContainer.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRemoveContainer.groovy
@@ -1,0 +1,15 @@
+package com.palantir.gradle.docker.run
+
+class DockerRemoveContainer extends DockerRunBaseTask {
+
+    DockerRemoveContainer() {
+        super(DockerRemoveContainer.class)
+        group = 'Docker Run'
+        description = 'Removes the persistent container associated with the Docker Run tasks'
+        ignoreExitValue = true
+        project.afterEvaluate {
+            commandLine 'docker', 'rm', containerName
+        }
+    }
+
+}

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRemoveContainer.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRemoveContainer.groovy
@@ -8,7 +8,7 @@ class DockerRemoveContainer extends DockerRunBaseTask {
         description = 'Removes the persistent container associated with the Docker Run tasks'
         ignoreExitValue = true
         project.afterEvaluate {
-            commandLine 'docker', 'rm', containerName
+            commandLine 'docker', 'rm', containerName.get()
         }
     }
 

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRun.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRun.groovy
@@ -70,12 +70,12 @@ class DockerRun extends DockerRunBaseTask {
                 args.add("${localFile.absolutePath}:${volume.value}")
             }
             args.addAll(env.get().collect { k, v -> ['-e', "${k}=${v}"] }.flatten())
-            args.addAll(['--name', containerName.get(), image.get()])
+            args.addAll(['--name', containerName.getOrNull(), image.getOrNull()])
             if (!command.get().isEmpty()) {
                 args.addAll(command.get())
             }
-            assert !args.contains(null)
             commandLine args
+
         }
     }
 

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRun.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRun.groovy
@@ -12,7 +12,6 @@ import org.gradle.internal.logging.text.StyledTextOutputFactory
 class DockerRun extends DockerRunBaseTask {
 
     Property<String> image = project.objects.property(String)
-    Property<String> network = project.objects.property(String)
     Property<List<String>> command = project.objects.property(List)
     Property<Set<String>> ports = project.objects.property(Set)
     Property<Map<String, String>> env = project.objects.property(Map)
@@ -26,7 +25,6 @@ class DockerRun extends DockerRunBaseTask {
         description = 'Runs the specified container with port mappings'
 
         image.set(getExtension().image)
-        network.set(getExtension().network)
         command.set(getExtension().command)
         ports.set(getExtension().ports)
         env.set(getExtension().env)
@@ -81,10 +79,6 @@ class DockerRun extends DockerRunBaseTask {
 
     def image(String image) {
         this.image.set image
-    }
-
-    def network(String network) {
-        this.network.set network
     }
 
     def env(Map<String, String> env) {

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRun.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRun.groovy
@@ -1,17 +1,16 @@
-package com.palantir.gradle.docker
+package com.palantir.gradle.docker.run
 
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
 import com.google.common.collect.Lists
-import org.gradle.api.tasks.AbstractExecTask
+import com.palantir.gradle.docker.DockerRunPlugin
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
-class DockerRunTask extends AbstractExecTask {
+class DockerRun extends DockerRunBaseTask {
 
-    String containerName
     String image
     String network
     List<String> command = ImmutableList.of()
@@ -21,8 +20,8 @@ class DockerRunTask extends AbstractExecTask {
     boolean daemonize = true
     boolean clean = false
 
-    DockerRunTask() {
-        super(DockerRunTask.class)
+    DockerRun() {
+        super(DockerRun.class)
         group = 'Docker Run'
         description = 'Runs the specified container with port mappings'
         project.afterEvaluate {
@@ -63,14 +62,6 @@ class DockerRunTask extends AbstractExecTask {
             assert !args.contains(null)
             commandLine args
         }
-    }
-
-    def name(String name) {
-        this.containerName = name
-    }
-
-    def containerName(String containerName) {
-        this.containerName = containerName
     }
 
     def image(String image) {

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRunBaseTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRunBaseTask.groovy
@@ -1,19 +1,33 @@
 package com.palantir.gradle.docker.run
 
+import com.palantir.gradle.docker.DockerRunExtension
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.AbstractExecTask
 
 abstract class DockerRunBaseTask extends AbstractExecTask {
-    String containerName
+    Property<String> containerName = project.objects.property(String)
+    Provider<String> network = project.objects.property(String)
 
     DockerRunBaseTask(Class taskType) {
         super(taskType)
+        containerName.set(getExtension().name)
+        network.set(getExtension().network)
+    }
+
+    protected DockerRunExtension getExtension() {
+        project.getExtensions().getByType(DockerRunExtension.class)
     }
 
     def name(String name) {
-        this.containerName = name
+        this.containerName.set name
     }
 
     def containerName(String containerName) {
-        this.containerName = containerName
+        this.containerName.set containerName
+    }
+
+    def network(String network) {
+        this.network.set network
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRunBaseTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRunBaseTask.groovy
@@ -1,0 +1,19 @@
+package com.palantir.gradle.docker.run
+
+import org.gradle.api.tasks.AbstractExecTask
+
+abstract class DockerRunBaseTask extends AbstractExecTask {
+    String containerName
+
+    DockerRunBaseTask(Class taskType) {
+        super(taskType)
+    }
+
+    def name(String name) {
+        this.containerName = name
+    }
+
+    def containerName(String containerName) {
+        this.containerName = containerName
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRunStatus.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRunStatus.groovy
@@ -1,6 +1,7 @@
 package com.palantir.gradle.docker.run
 
 class DockerRunStatus extends DockerRunBaseTask {
+
     DockerRunStatus() {
         super(DockerRunStatus.class)
         group = 'Docker Run'
@@ -8,14 +9,15 @@ class DockerRunStatus extends DockerRunBaseTask {
 
         project.afterEvaluate {
             standardOutput = new ByteArrayOutputStream()
-            commandLine 'docker', 'inspect', '--format={{.State.Running}}', containerName
-            doLast {
-                if (standardOutput.toString().trim() != 'true') {
-                    println "Docker container '${containerName}' is STOPPED."
-                    return 1
-                } else {
-                    println "Docker container '${containerName}' is RUNNING."
-                }
+            commandLine 'docker', 'inspect', '--format={{.State.Running}}', containerName.get()
+        }
+
+        doLast {
+            if (standardOutput.toString().trim() != 'true') {
+                println "Docker container '${containerName.get()}' is STOPPED."
+                return 1
+            } else {
+                println "Docker container '${containerName.get()}' is RUNNING."
             }
         }
     }

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRunStatus.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRunStatus.groovy
@@ -1,0 +1,22 @@
+package com.palantir.gradle.docker.run
+
+class DockerRunStatus extends DockerRunBaseTask {
+    DockerRunStatus() {
+        super(DockerRunStatus.class)
+        group = 'Docker Run'
+        description = 'Checks the run status of the container'
+
+        project.afterEvaluate {
+            standardOutput = new ByteArrayOutputStream()
+            commandLine 'docker', 'inspect', '--format={{.State.Running}}', containerName
+            doLast {
+                if (standardOutput.toString().trim() != 'true') {
+                    println "Docker container '${containerName}' is STOPPED."
+                    return 1
+                } else {
+                    println "Docker container '${containerName}' is RUNNING."
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerRunStatus.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerRunStatus.groovy
@@ -9,15 +9,15 @@ class DockerRunStatus extends DockerRunBaseTask {
 
         project.afterEvaluate {
             standardOutput = new ByteArrayOutputStream()
-            commandLine 'docker', 'inspect', '--format={{.State.Running}}', containerName.get()
+            commandLine 'docker', 'inspect', '--format={{.State.Running}}', containerName.getOrNull()
         }
 
         doLast {
             if (standardOutput.toString().trim() != 'true') {
-                println "Docker container '${containerName.get()}' is STOPPED."
+                println "Docker container '${containerName.getOrNull()}' is STOPPED."
                 return 1
             } else {
-                println "Docker container '${containerName.get()}' is RUNNING."
+                println "Docker container '${containerName.getOrNull()}' is RUNNING."
             }
         }
     }

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerStop.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerStop.groovy
@@ -8,7 +8,7 @@ class DockerStop extends DockerRunBaseTask {
         description = 'Stops the named container if it is running'
         ignoreExitValue = true
         project.afterEvaluate {
-            commandLine 'docker', 'stop', containerName
+            commandLine 'docker', 'stop', containerName.get()
         }
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerStop.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerStop.groovy
@@ -1,0 +1,14 @@
+package com.palantir.gradle.docker.run
+
+class DockerStop extends DockerRunBaseTask {
+
+    DockerStop() {
+        super(DockerStop.class)
+        group = 'Docker Run'
+        description = 'Stops the named container if it is running'
+        ignoreExitValue = true
+        project.afterEvaluate {
+            commandLine 'docker', 'stop', containerName
+        }
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/run/DockerStop.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/run/DockerStop.groovy
@@ -8,7 +8,7 @@ class DockerStop extends DockerRunBaseTask {
         description = 'Stops the named container if it is running'
         ignoreExitValue = true
         project.afterEvaluate {
-            commandLine 'docker', 'stop', containerName.get()
+            commandLine 'docker', 'stop', containerName.getOrNull()
         }
     }
 }

--- a/src/test/groovy/com/palantir/gradle/docker/AbstractPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/AbstractPluginTest.groovy
@@ -33,11 +33,13 @@ class AbstractPluginTest extends Specification {
     }
 
     GradleRunner with(String... tasks) {
+        def args = new ArrayList<String>(Arrays.asList(tasks))
+        args.add("--stacktrace")
         return GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments(tasks)
-            .withPluginClasspath()
-            .withDebug(true)
+                .withProjectDir(projectDir)
+                .withArguments(args)
+                .withPluginClasspath()
+                .withDebug(true)
     }
 
     String exec(String task) {

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -109,14 +109,14 @@ class DockerRunPluginTests extends AbstractPluginTest {
                 id 'com.palantir.docker-run'
             }
 
-            dockerRunExtension {
+            dockerRun {
                 name 'bar'
                 image 'alpine:3.2'
                 command 'sleep', '1000'
             }
             
             task another(type:DockerRunTask){
-                nameContainer 'foo'
+                name 'foo'
                 image 'alpine:3.2'
                 command 'sleep', '1000'
             }

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -157,6 +157,19 @@ class DockerRunPluginTests extends AbstractPluginTest {
         offline.output =~ /(?m):anotherRunStatus\RDocker container 'anotherName' is STOPPED./
     }
 
+    def 'can initialize without specifying dockerRun'() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.docker-run'
+            }
+        '''.stripIndent()
+        when:
+        BuildResult buildResult = with('help').build()
+        then:
+        buildResult.task(':help').outcome == TaskOutcome.SUCCESS
+    }
+
     def 'can run container with configured network'() {
         given:
         buildFile << '''

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -52,16 +52,16 @@ class DockerRunPluginTests extends AbstractPluginTest {
 
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         // CircleCI build nodes print a WARNING
-        buildResult.output =~ /(?m):dockerRun(WARNING:.*\n)?\n[A-Za-z0-9]+/
+        buildResult.output =~ /(?m):dockerRun(WARNING:.*\R)?\R[A-Za-z0-9]+/
 
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is RUNNING./
+        buildResult.output =~ /(?m):dockerRunStatus\RDocker container 'foo' is RUNNING./
 
         buildResult.task(':dockerStop').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerStop\nfoo/
+        buildResult.output =~ /(?m):dockerStop\Rfoo/
 
         offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        offline.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
+        offline.output =~ /(?m):dockerRunStatus\RDocker container 'foo' is STOPPED./
 
         execCond('docker rmi -f foo-image')
     }
@@ -90,16 +90,16 @@ class DockerRunPluginTests extends AbstractPluginTest {
 
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         // CircleCI build nodes print a WARNING
-        buildResult.output =~ /(?m):dockerRun(WARNING:.*\n)?\n[A-Za-z0-9]+/
+        buildResult.output =~ /(?m):dockerRun(WARNING:.*\R)?\R[A-Za-z0-9]+/
 
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is RUNNING./
+        buildResult.output =~ /(?m):dockerRunStatus\RDocker container 'bar' is RUNNING./
 
         buildResult.task(':dockerStop').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerStop\nbar/
+        buildResult.output =~ /(?m):dockerStop\Rbar/
 
         offline.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        offline.output =~ /(?m):dockerRunStatus\nDocker container 'bar' is STOPPED./
+        offline.output =~ /(?m):dockerRunStatus\RDocker container 'bar' is STOPPED./
     }
 
     def 'can run container with configured network' () {
@@ -123,7 +123,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
 
 		buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
 
-		buildResult.output =~ /(?m):dockerNetworkModeStatus\nDocker container 'bar-hostnetwork' is configured to run with 'host' network mode./
+		buildResult.output =~ /(?m):dockerNetworkModeStatus\RDocker container 'bar-hostnetwork' is configured to run with 'host' network mode./
 	}
 
     def 'can optionally not daemonize'() {
@@ -151,7 +151,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
 
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'bar-nodaemonize' is STOPPED./
+        buildResult.output =~ /(?m):dockerRunStatus\RDocker container 'bar-nodaemonize' is STOPPED./
     }
 
     def 'can mount volumes'() {
@@ -198,7 +198,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m)HELLO WORLD/
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
+        buildResult.output =~ /(?m):dockerRunStatus\RDocker container 'foo' is STOPPED./
     }
 
     def 'can mount volumes specified with an absolute path'() {
@@ -210,6 +210,11 @@ class DockerRunPluginTests extends AbstractPluginTest {
 
         given:
         File testFolder = directory("test")
+        def absolutePath = testFolder.absolutePath
+        if(isWindows()){
+            absolutePath = absolutePath.replace("\\", "/")
+        }
+
         file('Dockerfile') << '''
             FROM alpine:3.2
 
@@ -230,7 +235,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
             dockerRun {
                 name 'foo'
                 image 'foo-image:latest'
-                volumes "${testFolder.absolutePath}": "/test"
+                volumes "${absolutePath}": "/test"
                 daemonize false
             }
         """.stripIndent()
@@ -245,7 +250,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m)HELLO WORLD/
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo' is STOPPED./
+        buildResult.output =~ /(?m):dockerRunStatus\RDocker container 'foo' is STOPPED./
     }
 
     def 'can run with environment variables'() {
@@ -288,9 +293,12 @@ class DockerRunPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerRun').outcome == TaskOutcome.SUCCESS
         buildResult.output =~ /(?m)FOO = BAR = QUUY = ZIP/
         buildResult.task(':dockerRunStatus').outcome == TaskOutcome.SUCCESS
-        buildResult.output =~ /(?m):dockerRunStatus\nDocker container 'foo-envvars' is STOPPED./
+        buildResult.output =~ /(?m):dockerRunStatus\RDocker container 'foo-envvars' is STOPPED./
     }
 
+    def isWindows() {
+        return System.getProperty("os.name") =~ /.*Windows.*/
+    }
 
     def isLinux() {
         return System.getProperty("os.name") =~ /(?i).*linux.*/

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -115,7 +115,7 @@ class DockerRunPluginTests extends AbstractPluginTest {
                 command 'sleep', '1000'
             }
             
-            task another(type:DockerRunTask){
+            task another(type:DockerRun){
                 name 'foo'
                 image 'alpine:3.2'
                 command 'sleep', '1000'


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Currently only one set of task is generated for dockerRun. If you want multiple containers to Run it is impossible. 
Normaly it is expected in Gradle to be able to modify and extend tasks like : `task newThing(type: DockerRun){}` this is not possible at the moment and throws a cryptic error message. 

## After this PR
Using [this example](https://github.com/gradle-guides/gradle-site-plugin) we are now using lazy evaluation with properties for the configuration of now extracted tasks. 
There is no DSL change needed to have the same static tasks as before. However now new Tasks can be created using gradle DSL.
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
For every DockerRun Task created there is a new Status Task. That is the Task run after DockerRun is run (`finalizedBy`).
<!-- Please describe any way users could be negatively affected by this PR. -->

## Input needed:
There is some duplicated code in DockerRun and DockerRunExtension, namely the setter logic. What are suggestions to resolve that? 
