### PR TITLE
docker-run plugin - save container logs

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -56,6 +56,11 @@ class DockerRunPlugin implements Plugin<Project> {
             description = 'Checks the network configuration of the container'
         })
 
+        Exec dockerSaveContainerLog = project.tasks.create('dockerSaveContainerLog', Exec, {
+            group = 'Docker Run'
+            description = 'Save container log file in project build directory'
+        })
+
         project.afterEvaluate {
             dockerRunStatus.with {
                 standardOutput = new ByteArrayOutputStream()
@@ -139,6 +144,21 @@ class DockerRunPlugin implements Plugin<Project> {
 
             dockerRemoveContainer.with {
                 commandLine 'docker', 'rm', ext.name
+            }
+
+            dockerSaveContainerLog.with {
+                commandLine 'docker', 'logs', ext.name
+
+                doFirst {
+                    def projectDir = "${project.buildDir}"
+                    def logFilename = "docker-container-${ext.name}.log"
+
+                    def logFile =  new File(projectDir, logFilename)
+                    logFile.getParentFile().mkdirs()
+
+                    standardOutput = new FileOutputStream(logFile);
+                    println "Saved log file to $projectDir with name $logFilename"
+                }
             }
         }
     }

--- a/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerRunPluginTests.groovy
@@ -373,15 +373,5 @@ class DockerRunPluginTests extends AbstractPluginTest {
         return System.getenv("CI") == "true"
     }
 
-    def assertThatContainerLogExist(){
-        projectDir.eachFileRecurse(FileType.FILES){
-            if(it.name.endsWith('.log')){
-                println it
-            }
-        }
-
-        true
-    }
-
 
 }


### PR DESCRIPTION
## Before this PR
As I user, I would like to save container logs with palantir docker-run plugin. Right now functionality is missing in plugin and needs to be performed outside of it in dirty way.

## After this PR
* Adds new task in docker-run plugin called "dockerSaveContainerLog" that's executing "docker logs" and saving it to project build directory
* Unit test coverage for the new functionality

## Possible downsides?
* Tested this task with containers with log output up to 100M, possibly G+ logs should be tested 
* Executing task outside of container life cycle (i.e before it is started, after it is removed) fails, this is expected. Possibly some sanity check could be introduced to prevent such behaviour.

