### PR TITLE
add support for extra docker-compose options

### DIFF
--- a/changelog/@unreleased/pr-358.v2.yml
+++ b/changelog/@unreleased/pr-358.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add support for extra options for dockerComposeUp and dockerComposeDown configurable using the dockerCompose extension.
+  links:
+    - https://github.com/palantir/gradle-docker/pull/358

--- a/readme.md
+++ b/readme.md
@@ -214,7 +214,7 @@ version.
 
 **Configuring the `docker-compose` plugin**
 
-The template location, the generated file locations, and optional arguments for
+The template location, the generated file location, and optional arguments for
 `docker-compose` are customizable using the `dockerCompose` extension:
 
 ```gradle

--- a/readme.md
+++ b/readme.md
@@ -212,15 +212,17 @@ conflicts between transitive dependencies of the same artifact are handled with
 the standard Gradle semantics: each artifact is resolved to the highest declared
 version.
 
-**Configuring file locations**
+**Configuring the `docker-compose` plugin**
 
-The template and generated file locations are customizable through the
-`dockerCompose` extension:
+The template location, the generated file locations, and optional arguments for
+`docker-compose` are customizable using the `dockerCompose` extension:
 
 ```gradle
 dockerCompose {
     template 'my-template.yml'
     dockerComposeFile 'my-docker-compose.yml'
+    upArguments '--build', '--force-recreate'
+    downArguments '--rmi', 'all'
 }
 ```
 
@@ -286,7 +288,7 @@ Tasks
    * `generateDockerCompose`: Populates a docker-compose file template with image
      versions declared by dependencies
    * `dockerComposeUp`: Brings up services defined in `dockerComposeFile` in
-     detacted state
+     detached state
    * `dockerComposeDown`: Stops services defined in `dockerComposeFile`
  * **Docker Run**
    * `dockerRun`: run the specified image with the specified name

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeDown.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeDown.groovy
@@ -34,7 +34,7 @@ class DockerComposeDown extends DefaultTask {
     void run() {
         project.exec {
             it.executable "docker-compose"
-            it.args "-f", getDockerComposeFile(), "down"
+            it.args getArguments()
         }
     }
 
@@ -45,5 +45,9 @@ class DockerComposeDown extends DefaultTask {
 
     DockerComposeExtension getDockerComposeExtension() {
         return project.extensions.findByType(DockerComposeExtension)
+    }
+
+    List<String> getArguments() {
+        return ["-f", getDockerComposeFile(), "down"] + dockerComposeExtension.downArguments
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
@@ -16,6 +16,7 @@
 package com.palantir.gradle.docker
 
 import com.google.common.collect.Maps
+import com.google.common.collect.ImmutableList
 import org.gradle.api.Project
 
 class DockerComposeExtension {
@@ -24,6 +25,8 @@ class DockerComposeExtension {
     private File template
     private File dockerComposeFile
     private Map<String, String> templateTokens = Maps.newHashMap()
+    private List<String> upArguments = ImmutableList.of()
+    private List<String> downArguments = ImmutableList.of()
 
     public DockerComposeExtension(Project project) {
         this.project = project
@@ -47,6 +50,14 @@ class DockerComposeExtension {
         this.templateTokens.put(key, value)
     }
 
+    public void upArguments(String... upArguments) {
+        this.upArguments = ImmutableList.copyOf(upArguments)
+    }
+
+    public void downArguments(String... downArguments) {
+        this.downArguments = ImmutableList.copyOf(downArguments)
+    }
+
     Map<String, String> getTemplateTokens() {
         return templateTokens
     }
@@ -57,5 +68,13 @@ class DockerComposeExtension {
 
     File getDockerComposeFile() {
         return dockerComposeFile
+    }
+
+    List<String> getUpArguments() {
+        return upArguments
+    }
+
+    List<String> getDownArguments() {
+        return downArguments
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposePlugin.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.Configuration
 class DockerComposePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.extensions.create('dockerCompose', DockerComposeExtension, project)
+        DockerComposeExtension extension = project.extensions.create('dockerCompose', DockerComposeExtension, project)
         Configuration dockerConfiguration = project.configurations.maybeCreate('docker')
 
         // sls-packaging adds a 'productDependencies' configuration, which contains the inferred lower bounds of products

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeUp.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeUp.groovy
@@ -34,7 +34,7 @@ class DockerComposeUp extends DefaultTask {
     void run() {
         project.exec {
             it.executable "docker-compose"
-            it.args "-f", getDockerComposeFile(), "up", "-d"
+            it.args getArguments()
         }
     }
 
@@ -51,5 +51,9 @@ class DockerComposeUp extends DefaultTask {
 
     DockerComposeExtension getDockerComposeExtension() {
         return project.extensions.findByType(DockerComposeExtension)
+    }
+
+    List<String> getArguments() {
+        return ["-f", getDockerComposeFile(), "up", "-d"] + dockerComposeExtension.upArguments
     }
 }

--- a/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
@@ -290,7 +290,7 @@ class DockerComposePluginTests extends AbstractPluginTest {
             }
             
             dockerCompose {
-                // force build every time
+                // remove images
                 downArguments '--rmi', 'all'
             }
         '''.stripIndent()


### PR DESCRIPTION
## Before this PR
It's not possible to supply options to `docker-compose` as invoked by the `dockerComposeUp` and `dockerComposeDown` tasks. Some users may wish to supply e.g. the `--build` option to `docker-compose up` if their compose file declares services which include a [`build`](https://docs.docker.com/compose/compose-file/#build) option.

## After this PR
* Add support for extra options for dockerComposeUp and dockerComposeDown configurable using the dockerCompose extension.

## Possible downsides?
n/a

