### PR TITLE
Improving null pointer exception with templateTokens

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeExtension.groovy
@@ -15,6 +15,7 @@
  */
 package com.palantir.gradle.docker
 
+import static com.google.common.base.Preconditions.checkNotNull
 import com.google.common.collect.Maps
 import org.gradle.api.Project
 
@@ -40,6 +41,7 @@ class DockerComposeExtension {
     }
 
     public void setTemplateTokens(Map<String, String> templateTokens) {
+        templateTokens.forEach({templateTokenKey, templateTokenValue -> checkNotNull(templateTokenValue, String.format("Supplied templateToken property [%s] value is null", templateTokenKey))})
         this.templateTokens = templateTokens
     }
 

--- a/src/test/groovy/com/palantir/gradle/docker/AbstractPluginTest.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/AbstractPluginTest.groovy
@@ -83,14 +83,14 @@ class AbstractPluginTest extends Specification {
         }
     }
 
-    protected int processCount() {
+    protected boolean isProcessRunning(String processName) {
         StringBuffer sout = new StringBuffer(), serr = new StringBuffer()
-        Process proc = 'docker ps -q'.execute()
+        Process proc = 'docker ps -q -f "name=$processName'.execute()
         proc.consumeProcessOutput(sout, serr)
         proc.waitFor()
         assert proc.exitValue() == 0
 
-        return sout.readLines().size()
+        return sout.readLines().size() != 0
     }
 
     protected String escapePath(String path) {

--- a/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/DockerComposePluginTests.groovy
@@ -17,6 +17,7 @@ package com.palantir.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
 
 class DockerComposePluginTests extends AbstractPluginTest {
 
@@ -240,6 +241,23 @@ class DockerComposePluginTests extends AbstractPluginTest {
         when:
         with('dockerComposeDown').build()
         then:
-        processCount() == 0
+        !isProcessRunning('unit-test-docker-compose-stop')
+    }
+
+    def 'docker-compose setTemplateTokens with null values throw exceptions'() {
+        given:
+        buildFile << '''
+            plugins {
+                id 'com.palantir.docker-compose'
+            }
+            dockerCompose {
+                templateTokens = ["aProperty": null]
+            }
+        '''.stripIndent()
+        when:
+        with('dockerComposeUp').build()
+        then:
+        def e = thrown(UnexpectedBuildFailure)
+        e.message.contains("Supplied templateToken property [aProperty] value is null")
     }
 }


### PR DESCRIPTION
## Before this PR
A NullPointerException with no description/message/indication of what was wrong was thrown when supplying templateTokens with a valid key and a NULL value.

The 'docker-compose stop successfully stops docker container' test would fail if you're running any docker containers locally when running the test.

## After this PR
==COMMIT_MSG==
A more useful and friendly message is displayed when a null value is supplied in templateTokens.

The 'docker-compose stop successfully stops docker container' now just checks the container it brings up is also taken down - ignoring any other docker containers you may be running.
==COMMIT_MSG==

## Possible downsides?
None

