### PR TITLE
Add 'quiet' parameter to reduce noisy output

### DIFF
--- a/changelog/@unreleased/pr-445.v1.yaml
+++ b/changelog/@unreleased/pr-445.v1.yaml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add 'quiet' parameter to reduce noisy output
+  links:
+    - https://github.com/palantir/gradle-docker/pull/445

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,9 @@ build/
 - `pull` (optional) a boolean argument which defines whether Docker should attempt to pull
   a newer version of the base image before building; defaults to `false`
 - `noCache` (optional) a boolean argument which defines whether Docker build should add the option --no-cache,
-    so that it rebuilds the whole image from scratch; defaults to `false`
+  so that it rebuilds the whole image from scratch; defaults to `false`
+- `quiet` (optional) a boolean argument which defines whether Docker build should add the option --quiet,
+  so that 
 
 To build a docker container, run the `docker` task. To push that container to a
 docker repository, run the `dockerPush` task.
@@ -102,6 +104,7 @@ docker {
     labels(['key': 'value'])
     pull true
     noCache true
+    quiet true
 }
 ```
 

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -40,6 +40,7 @@ class DockerExtension {
     private Map<String, String> buildArgs = ImmutableMap.of()
     private boolean pull = false
     private boolean noCache = false
+    private boolean quiet = false
     private String network = null
 
     private File resolvedDockerfile = null
@@ -173,5 +174,13 @@ class DockerExtension {
 
     public void noCache(boolean noCache) {
         this.noCache = noCache
+    }
+
+    public boolean getQuiet() {
+        return quiet
+    }
+
+    public void quiet(boolean quiet) {
+        this.quiet = quiet
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -202,6 +202,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
         if (ext.pull) {
             buildCommandLine.add '--pull'
         }
+        if (ext.quiet) {
+            buildCommandLine.add '--quiet'
+        }
         buildCommandLine.addAll(['-t', "${-> ext.name}", '.'])
         return buildCommandLine
     }

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -461,6 +461,37 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         execCond("docker rmi -f ${id}")
     }
 
+
+    def 'build quietly when "quiet" parameter is set'() {
+        given:
+        String id = 'id66'
+        String filename = "bar.txt"
+        file('Dockerfile') << """
+            FROM alpine:3.2
+            ADD ${filename} /tmp/
+        """.stripIndent()
+        buildFile << """
+            plugins {
+                id 'com.palantir.docker'
+            }
+
+            docker {
+                name '${id}'
+                files "${filename}"
+                quiet true
+            }
+        """.stripIndent()
+        createFile(filename)
+
+        when:
+        BuildResult buildResult = with('-i', 'docker').build()
+
+        then:
+        buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
+        buildResult.task(':docker').outcome == TaskOutcome.SUCCESS
+        execCond("docker rmi -f ${id}")
+    }
+
     def 'can build docker with network mode configured'() {
         given:
         String id = 'id11'


### PR DESCRIPTION
Passes '--quiet' to docker build in order to reduce the build ouput
significantly. 

## Before this PR
The plugin pollutes the Gradle log too much, especially when multiple Gradle modules with containers are part of the same project.

## After this PR
Less noise.

## Possible downsides?
None, the flag is optional and off by default.
