### PR TITLE
Allow running multiple docker images with the docker-run plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,7 +266,26 @@ dockerRun {
 - `command` the command to run.
 - `arguments` additional arguments to be passed into the docker run command.
    Please see https://docs.docker.com/engine/reference/run/ for possible values.
-   
+
+**Multiple Docker Run Instances**
+You can run more than 1 docker image by creating multiple DockerRunExtension instances:
+```gradle
+import com.palantir.gradle.docker.DockerRunExtension
+
+
+extensions.create("dockerUbuntu", DockerRunExtension, "dockerUbuntu", project)
+
+// This will provide another set of Docker Run tasks (e.g. `dockerUbuntuRun`, `dockerUbuntuStop`)
+dockerUbuntu {
+    name "dev-ubuntu-${project.name}"
+    image "ubuntu:latest"
+    command "sleep", "10"
+    clean true
+    ports "8080:8080"
+    daemonize true
+}
+```
+
 Tasks
 -----
 

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -15,15 +15,14 @@
  */
 package com.palantir.gradle.docker
 
-import static com.google.common.base.Preconditions.checkNotNull
-
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
 
-class DockerRunExtension {
+import static com.google.common.base.Preconditions.checkNotNull
 
+class DockerRunExtension {
     private String name
     private String image
     private String network
@@ -34,6 +33,7 @@ class DockerRunExtension {
     private Map<Object,String> volumes = ImmutableMap.of()
     private boolean daemonize = true
     private boolean clean = false
+    final static String DEFAULT_EXTENSION_NAME ="dockerRun"
 
     public String getName() {
         return name

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -39,7 +39,6 @@ class DockerRunExtension {
 
     DockerRunExtension(String extensionName, Project project) {
         String taskNamePrefix = 'docker'
-        println("SR" + extensionName)
         if (DEFAULT_EXTENSION_NAME != extensionName) {
             taskNamePrefix = extensionName
         }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunExtension.groovy
@@ -15,12 +15,14 @@
  */
 package com.palantir.gradle.docker
 
+import static com.google.common.base.Preconditions.checkNotNull
+
 import com.google.common.base.Preconditions
 import com.google.common.collect.ImmutableList
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
-
-import static com.google.common.base.Preconditions.checkNotNull
+import com.palantir.gradle.docker.task.dockerrun.*
+import org.gradle.api.Project
 
 class DockerRunExtension {
     private String name
@@ -28,66 +30,79 @@ class DockerRunExtension {
     private String network
     private List<String> command = ImmutableList.of()
     private Set<String> ports = ImmutableSet.of()
-    private Map<String,String> env = ImmutableMap.of()
+    private Map<String, String> env = ImmutableMap.of()
     private List<String> arguments = ImmutableList.of()
-    private Map<Object,String> volumes = ImmutableMap.of()
+    private Map<Object, String> volumes = ImmutableMap.of()
     private boolean daemonize = true
     private boolean clean = false
-    final static String DEFAULT_EXTENSION_NAME ="dockerRun"
+    static final String DEFAULT_EXTENSION_NAME = "dockerRun"
 
-    public String getName() {
+    DockerRunExtension(String extensionName, Project project) {
+        String taskNamePrefix = 'docker'
+        println("SR" + extensionName)
+        if (DEFAULT_EXTENSION_NAME != extensionName) {
+            taskNamePrefix = extensionName
+        }
+        project.tasks.register("${taskNamePrefix}Run", DockerRunTask, this)
+        project.tasks.register("${taskNamePrefix}Stop", DockerStopTask, this)
+        project.tasks.register("${taskNamePrefix}RemoveContainer", DockerRemoveTask, this)
+        project.tasks.register("${taskNamePrefix}RunStatus", DockerRunStatusTask, this)
+        project.tasks.register("${taskNamePrefix}NetworkModeStatus", DockerNetworkModeStatusTask, this)
+    }
+
+    String getName() {
         return name
     }
 
-    public void setName(String name) {
+    void setName(String name) {
         this.name = name
     }
 
-    public boolean getDaemonize() {
+    boolean getDaemonize() {
         return daemonize
     }
 
-    public void setDaemonize(boolean daemonize) {
+    void setDaemonize(boolean daemonize) {
         this.daemonize = daemonize
     }
 
-    public boolean getClean() {
+    boolean getClean() {
         return clean
     }
 
-    public void setClean(boolean clean) {
+    void setClean(boolean clean) {
         this.clean = clean
     }
 
-    public String getImage() {
+    String getImage() {
         return image
     }
 
-    public void setImage(String image) {
+    void setImage(String image) {
         this.image = image
     }
 
-    public Set<String> getPorts() {
+    Set<String> getPorts() {
         return ports
     }
 
-    public List<String> getCommand() {
+    List<String> getCommand() {
         return command
     }
 
-    public Map<Object,String> getVolumes() {
+    Map<Object, String> getVolumes() {
         return volumes
     }
 
-    public void command(String... command) {
+    void command(String... command) {
         this.command = ImmutableList.copyOf(command)
     }
 
-    public void setNetwork(String network) {
+    void setNetwork(String network) {
         this.network = network
     }
 
-    public String getNetwork() {
+    String getNetwork() {
         return network
     }
 
@@ -95,23 +110,23 @@ class DockerRunExtension {
         this.env.put(checkNotNull(key, "key"), checkNotNull(value, "value"))
     }
 
-    public void env(Map<String,String> env) {
+    void env(Map<String, String> env) {
         this.env = ImmutableMap.copyOf(env)
     }
 
-    public Map<String, String> getEnv() {
+    Map<String, String> getEnv() {
         return env
     }
 
-    public void arguments(String... arguments) {
+    void arguments(String... arguments) {
         this.arguments = ImmutableList.copyOf(arguments)
     }
 
-    public List<String> getArguments() {
+    List<String> getArguments() {
         return arguments
     }
 
-    public void ports(String... ports) {
+    void ports(String... ports) {
         ImmutableSet.Builder builder = ImmutableSet.builder()
         for (String port : ports) {
             String[] mapping = port.split(':', 2)
@@ -127,8 +142,8 @@ class DockerRunExtension {
         this.ports = builder.build()
     }
 
-    public void volumes(Map<Object,String> volumes) {
-      this.volumes = ImmutableMap.copyOf(volumes)
+    void volumes(Map<Object, String> volumes) {
+        this.volumes = ImmutableMap.copyOf(volumes)
     }
 
     private static void checkPortIsValid(String port) {

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -15,131 +15,19 @@
  */
 package com.palantir.gradle.docker
 
-import com.google.common.collect.Lists
-import java.util.Map.Entry
+import com.palantir.gradle.docker.task.dockerrun.*
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.Exec
-import org.gradle.internal.logging.text.StyledTextOutput
-import org.gradle.internal.logging.text.StyledTextOutput.Style
-import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 class DockerRunPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        DockerRunExtension ext = project.extensions.create('dockerRun', DockerRunExtension)
-
-        Exec dockerRunStatus = project.tasks.create('dockerRunStatus', Exec, {
-            group = 'Docker Run'
-            description = 'Checks the run status of the container'
-        })
-
-        Exec dockerRun = project.tasks.create('dockerRun', Exec, {
-            group = 'Docker Run'
-            description = 'Runs the specified container with port mappings'
-        })
-
-        Exec dockerStop = project.tasks.create('dockerStop', Exec, {
-            group = 'Docker Run'
-            description = 'Stops the named container if it is running'
-            ignoreExitValue = true
-        })
-
-        Exec dockerRemoveContainer = project.tasks.create('dockerRemoveContainer', Exec, {
-            group = 'Docker Run'
-            description = 'Removes the persistent container associated with the Docker Run tasks'
-            ignoreExitValue = true
-        })
-
-        Exec dockerNetworkModeStatus = project.tasks.create('dockerNetworkModeStatus', Exec, {
-            group = 'Docker Run'
-            description = 'Checks the network configuration of the container'
-        })
-
-        project.afterEvaluate {
-            dockerRunStatus.with {
-                standardOutput = new ByteArrayOutputStream()
-                commandLine 'docker', 'inspect', '--format={{.State.Running}}', ext.name
-                doLast {
-                    if (standardOutput.toString().trim() != 'true') {
-                        println "Docker container '${ext.name}' is STOPPED."
-                        return 1
-                    } else {
-                        println "Docker container '${ext.name}' is RUNNING."
-                    }
-                }
-            }
-
-            dockerNetworkModeStatus.with {
-                standardOutput = new ByteArrayOutputStream()
-                commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', ext.name
-                doLast {
-                    def networkMode = standardOutput.toString().trim()
-                    if (networkMode == 'default') {
-                        println "Docker container '${ext.name}' has default network configuration (bridge)."
-                    }
-                    else {
-                        if (networkMode == ext.network) {
-                            println "Docker container '${ext.name}' is configured to run with '${ext.network}' network mode."
-                        }
-                        else {
-                            println "Docker container '${ext.name}' runs with '${networkMode}' network mode instead of the configured '${ext.network}'."
-                            return 1
-                        }
-                    }
-                }
-            }
-
-            dockerRun.with {
-                List<String> args = Lists.newArrayList()
-                args.addAll(['docker', 'run'])
-                if (ext.daemonize) {
-                  args.add('-d')
-                }
-                if (ext.clean) {
-                  args.add('--rm')
-                } else {
-                  finalizedBy dockerRunStatus
-                }
-                if (ext.network) {
-                    args.addAll(['--network', ext.network])
-                }
-                for (String port : ext.ports) {
-                    args.add('-p')
-                    args.add(port)
-                }
-                for (Entry<Object,String> volume : ext.volumes.entrySet()) {
-                    File localFile = project.file(volume.key)
-
-                    if (!localFile.exists()) {
-                       StyledTextOutput o = project.services.get(StyledTextOutputFactory.class).create(DockerRunPlugin)
-                       o.withStyle(Style.Error).println("ERROR: Local folder ${localFile} doesn't exist. Mounted volume will not be visible to container")
-                       throw new IllegalStateException("Local folder ${localFile} doesn't exist.")
-                    }
-
-                    args.add('-v')
-                    args.add("${localFile.absolutePath}:${volume.value}")
-                }
-                args.addAll(ext.env.collect{ k, v -> ['-e', "${k}=${v}"] }.flatten())
-                args.add('--name')
-                args.add(ext.name)
-                if (!ext.arguments.isEmpty()) {
-                    args.addAll(ext.arguments)
-                }
-                args.add(ext.image)
-                if (!ext.command.isEmpty()) {
-                    args.addAll(ext.command)
-                }
-                commandLine args
-            }
-
-            dockerStop.with {
-                commandLine 'docker', 'stop', ext.name
-            }
-
-            dockerRemoveContainer.with {
-                commandLine 'docker', 'rm', ext.name
-            }
-        }
+        DockerRunExtension defaultDockerRunExtension = project.extensions.create(DockerRunExtension.DEFAULT_EXTENSION_NAME, DockerRunExtension)
+        project.tasks.register('dockerRun', DockerRunTask, defaultDockerRunExtension)
+        project.tasks.register('dockerRunStatus', DockerRunStatusTask, defaultDockerRunExtension)
+        project.tasks.register('dockerStop', DockerStopTask, defaultDockerRunExtension)
+        project.tasks.register('dockerRemoveContainer', DockerRemoveTask, defaultDockerRunExtension)
+        project.tasks.register('dockerNetworkModeStatus', DockerNetworkModeStatusTask, defaultDockerRunExtension)
     }
+
 }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerRunPlugin.groovy
@@ -15,19 +15,13 @@
  */
 package com.palantir.gradle.docker
 
-import com.palantir.gradle.docker.task.dockerrun.*
+
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class DockerRunPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        DockerRunExtension defaultDockerRunExtension = project.extensions.create(DockerRunExtension.DEFAULT_EXTENSION_NAME, DockerRunExtension)
-        project.tasks.register('dockerRun', DockerRunTask, defaultDockerRunExtension)
-        project.tasks.register('dockerRunStatus', DockerRunStatusTask, defaultDockerRunExtension)
-        project.tasks.register('dockerStop', DockerStopTask, defaultDockerRunExtension)
-        project.tasks.register('dockerRemoveContainer', DockerRemoveTask, defaultDockerRunExtension)
-        project.tasks.register('dockerNetworkModeStatus', DockerNetworkModeStatusTask, defaultDockerRunExtension)
+        project.extensions.create(DockerRunExtension.DEFAULT_EXTENSION_NAME, DockerRunExtension, DockerRunExtension.DEFAULT_EXTENSION_NAME, project)
     }
-
 }

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/AbstractDockerRunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/AbstractDockerRunTask.groovy
@@ -1,0 +1,17 @@
+package com.palantir.gradle.docker.task.dockerrun
+
+import com.palantir.gradle.docker.DockerRunExtension
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.Input
+
+abstract class AbstractDockerRunTask extends Exec {
+    @Input
+    DockerRunExtension dockerRunExtension
+
+    AbstractDockerRunTask(DockerRunExtension injectedDockerRunExtension) {
+        super()
+        group = "Docker Run"
+
+        dockerRunExtension = injectedDockerRunExtension
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerNetworkModeStatusTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerNetworkModeStatusTask.groovy
@@ -1,0 +1,29 @@
+package com.palantir.gradle.docker.task.dockerrun
+
+import com.palantir.gradle.docker.DockerRunExtension
+
+import javax.inject.Inject
+
+class DockerNetworkModeStatusTask extends AbstractDockerRunTask {
+    @Inject
+    DockerNetworkModeStatusTask(DockerRunExtension injectedDockerRunExtension) {
+        super(injectedDockerRunExtension)
+        description = 'Checks the network configuration of the container'
+
+        standardOutput = new ByteArrayOutputStream()
+        commandLine 'docker', 'inspect', '--format={{.HostConfig.NetworkMode}}', dockerRunExtension.name
+        doLast {
+            def networkMode = standardOutput.toString().trim()
+            if (networkMode == 'default') {
+                println "Docker container '${dockerRunExtension.name}' has default network configuration (bridge)."
+            } else {
+                if (networkMode == dockerRunExtension.network) {
+                    println "Docker container '${dockerRunExtension.name}' is configured to run with '${dockerRunExtension.network}' network mode."
+                } else {
+                    println "Docker container '${dockerRunExtension.name}' runs with '${networkMode}' network mode instead of the configured '${dockerRunExtension.network}'."
+                    return 1
+                }
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRemoveTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRemoveTask.groovy
@@ -1,0 +1,16 @@
+package com.palantir.gradle.docker.task.dockerrun
+
+import com.palantir.gradle.docker.DockerRunExtension
+
+import javax.inject.Inject
+
+class DockerRemoveTask extends AbstractDockerRunTask {
+
+    @Inject
+    DockerRemoveTask(DockerRunExtension injectedDockerRunExtension) {
+        super(injectedDockerRunExtension)
+        description = 'Removes the persistent container associated with the Docker Run tasks'
+        ignoreExitValue = true
+        commandLine 'docker', 'rm', dockerRunExtension.name
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRunStatusTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRunStatusTask.groovy
@@ -1,0 +1,24 @@
+package com.palantir.gradle.docker.task.dockerrun
+
+import com.palantir.gradle.docker.DockerRunExtension
+
+import javax.inject.Inject
+
+class DockerRunStatusTask extends AbstractDockerRunTask {
+    @Inject
+    DockerRunStatusTask(DockerRunExtension injectedDockerRunExtension) {
+        super(injectedDockerRunExtension)
+        description = 'Checks the run status of the container'
+
+        standardOutput = new ByteArrayOutputStream()
+        commandLine 'docker', 'inspect', '--format={{.State.Running}}', dockerRunExtension.name
+        doLast {
+            if (standardOutput.toString().trim() != 'true') {
+                println "Docker container '${dockerRunExtension.name}' is STOPPED."
+                return 1
+            } else {
+                println "Docker container '${dockerRunExtension.name}' is RUNNING."
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRunTask.groovy
@@ -2,6 +2,7 @@ package com.palantir.gradle.docker.task.dockerrun
 
 import com.google.common.collect.Lists
 import com.palantir.gradle.docker.DockerRunExtension
+import org.gradle.api.Task
 import org.gradle.internal.logging.text.StyledTextOutput
 
 import javax.inject.Inject
@@ -21,9 +22,8 @@ class DockerRunTask extends AbstractDockerRunTask {
         if (dockerRunExtension.clean) {
             args.add('--rm')
         }
-        // TODO dynamic runStatus task
         else {
-            finalizedBy project.tasks.dockerRunStatus
+            finalizedBy name+"Status"
         }
         if (dockerRunExtension.network) {
             args.addAll(['--network', dockerRunExtension.network])

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRunTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerRunTask.groovy
@@ -1,0 +1,61 @@
+package com.palantir.gradle.docker.task.dockerrun
+
+import com.google.common.collect.Lists
+import com.palantir.gradle.docker.DockerRunExtension
+import org.gradle.internal.logging.text.StyledTextOutput
+
+import javax.inject.Inject
+
+class DockerRunTask extends AbstractDockerRunTask {
+
+    @Inject
+    DockerRunTask(DockerRunExtension injectedDockerRunExtension) {
+        super(injectedDockerRunExtension)
+        description = 'Runs the specified container with port mappings'
+
+        List<String> args = Lists.newArrayList()
+        args.addAll(['docker', 'run'])
+        if (dockerRunExtension.daemonize) {
+            args.add('-d')
+        }
+        if (dockerRunExtension.clean) {
+            args.add('--rm')
+        }
+        // TODO dynamic runStatus task
+        else {
+            finalizedBy project.tasks.dockerRunStatus
+        }
+        if (dockerRunExtension.network) {
+            args.addAll(['--network', dockerRunExtension.network])
+        }
+        for (String port : dockerRunExtension.ports) {
+            args.add('-p')
+            args.add(port)
+        }
+        for (Map.Entry<Object, String> volume : dockerRunExtension.volumes.entrySet()) {
+            File localFile = project.file(volume.key)
+
+            if (!localFile.exists()) {
+                StyledTextOutput o = project.services.get(StyledTextOutputFactory.class).create(DockerRunTask)
+                o.withStyle(StyledTextOutput.Style.Error).
+                println("ERROR: Local folder ${localFile} doesn't exist. Mounted volume will not be visible to container")
+                throw new IllegalStateException("Local folder ${localFile} doesn't exist.")
+            }
+
+            args.add('-v')
+            args.add("${localFile.absolutePath}:${volume.value}")
+        }
+        args.addAll(dockerRunExtension.env.collect { k, v -> ['-e', "${k}=${v}"] }.flatten())
+        args.add('--name')
+        args.add(dockerRunExtension.name)
+        if (!dockerRunExtension.arguments.isEmpty()) {
+            args.addAll(dockerRunExtension.arguments)
+        }
+        args.add(dockerRunExtension.image)
+        if (!dockerRunExtension.command.isEmpty()) {
+            args.addAll(dockerRunExtension.command)
+        }
+        commandLine args
+    }
+
+}

--- a/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerStopTask.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/task/dockerrun/DockerStopTask.groovy
@@ -1,0 +1,16 @@
+package com.palantir.gradle.docker.task.dockerrun
+
+import com.palantir.gradle.docker.DockerRunExtension
+
+import javax.inject.Inject
+
+class DockerStopTask extends AbstractDockerRunTask {
+
+    @Inject
+    DockerStopTask(DockerRunExtension injectedDockerRunExtension) {
+        super(injectedDockerRunExtension)
+        description = 'Stops the named container if it is running'
+        ignoreExitValue = true
+        commandLine 'docker', 'stop', dockerRunExtension.name
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
As mentioned in #418, currently it's only possible to run 1 docker image with the docker-run plugin.
Running more than 1 image requires the use of docker-compose.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow users to run multiple docker images with `docker-run` by specifying additional `DockerRunExtension` instances
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

