### PR TITLE
Include error output on external process execution failures

### DIFF
--- a/changelog/@unreleased/pr-481.v2.yml
+++ b/changelog/@unreleased/pr-481.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Include command output in exception if it fails.
+  links:
+  - https://github.com/palantir/gradle-docker/pull/481

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeDown.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeDown.groovy
@@ -35,7 +35,7 @@ class DockerComposeDown extends DefaultTask {
 
     @TaskAction
     void run() {
-        project.exec {
+        GradleExecUtils.execWithErrorMessage(project) {
             it.executable "docker-compose"
             it.args "-f", getDockerComposeFile(), "down"
         }

--- a/src/main/groovy/com/palantir/gradle/docker/DockerComposeUp.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerComposeUp.groovy
@@ -16,13 +16,12 @@
 
 package com.palantir.gradle.docker
 
+import groovy.util.logging.Slf4j
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-
-import groovy.util.logging.Slf4j
 
 @Slf4j
 class DockerComposeUp extends DefaultTask {
@@ -35,7 +34,7 @@ class DockerComposeUp extends DefaultTask {
 
     @TaskAction
     void run() {
-        project.exec {
+        GradleExecUtils.execWithErrorMessage(project) {
             it.executable "docker-compose"
             it.args "-f", getDockerComposeFile(), "up", "-d"
         }

--- a/src/main/groovy/com/palantir/gradle/docker/GradleExecUtils.java
+++ b/src/main/groovy/com/palantir/gradle/docker/GradleExecUtils.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.docker;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.process.ExecResult;
+import org.gradle.process.ExecSpec;
+
+final class GradleExecUtils {
+    public static void execWithErrorMessage(Project project, Action<ExecSpec> execSpecAction) {
+        List<String> commandLine = new ArrayList<>();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        ExecResult execResult = project.exec(execSpec -> {
+            execSpecAction.execute(execSpec);
+            execSpec.setIgnoreExitValue(true);
+            execSpec.setStandardOutput(output);
+            execSpec.setErrorOutput(output);
+            commandLine.addAll(execSpec.getCommandLine());
+        });
+
+        if (execResult.getExitValue() != 0) {
+            throw new GradleException(String.format(
+                    "The command '%s' failed with exit code %d. Output:\n%s",
+                    commandLine,
+                    execResult.getExitValue(),
+                    new String(output.toByteArray(), StandardCharsets.UTF_8)));
+        }
+    }
+
+    private GradleExecUtils() {}
+}


### PR DESCRIPTION
## Before this PR
When your `docker-compose up` fails, you get a completely useless exception message:

```
Caused by: org.gradle.process.internal.ExecException: Process ’command ‘docker-compose’' finished with non-zero exit value 1
```

## After this PR
==COMMIT_MSG==
Include command output in exception if it fails.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

