### PR TITLE
Output to stdout/stderr while docker-compose process is running

### DIFF
--- a/changelog/@unreleased/pr-482.v2.yml
+++ b/changelog/@unreleased/pr-482.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Ensure the progress of `docker-compose up` is printing to stderr/stdout
+    to prevent circle context deadlines being hit when pulling a large number of containers..
+  links:
+  - https://github.com/palantir/gradle-docker/pull/482

--- a/src/main/groovy/com/palantir/gradle/docker/GradleExecUtils.java
+++ b/src/main/groovy/com/palantir/gradle/docker/GradleExecUtils.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.tools.ant.util.TeeOutputStream;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -34,8 +35,8 @@ final class GradleExecUtils {
         ExecResult execResult = project.exec(execSpec -> {
             execSpecAction.execute(execSpec);
             execSpec.setIgnoreExitValue(true);
-            execSpec.setStandardOutput(output);
-            execSpec.setErrorOutput(output);
+            execSpec.setStandardOutput(new TeeOutputStream(System.out, output));
+            execSpec.setErrorOutput(new TeeOutputStream(System.err, output));
             commandLine.addAll(execSpec.getCommandLine());
         });
 


### PR DESCRIPTION
## Before this PR
In #481, we accidentally removed printing out the progress of docker-compose up as it went along. Some internal projects pull so many docker containers that when there is a docker layer cache miss, the build can go for >10 mins without output, leading Circle to kill the build.

## After this PR
==COMMIT_MSG==
Ensure the progress of `docker-compose up` is printing to stderr/stdout to prevent circle context deadlines being hit when pulling a large number of containers..
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

