### PR TITLE
Set mandatory defaults for the dockerfileZip task

### DIFF
--- a/changelog/@unreleased/pr-483.v1.yaml
+++ b/changelog/@unreleased/pr-483.v1.yaml
@@ -1,0 +1,5 @@
+type: fix
+improvement:
+  description: Default values for dockerfileZip tasks.
+  links:
+    - https://github.com/palantir/gradle-docker/pull/483

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -15,8 +15,6 @@
  */
 package com.palantir.gradle.docker
 
-import org.gradle.api.file.Directory
-
 import java.util.regex.Pattern
 import javax.inject.Inject
 import org.gradle.api.GradleException

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -15,6 +15,8 @@
  */
 package com.palantir.gradle.docker
 
+import org.gradle.api.file.Directory
+
 import java.util.regex.Pattern
 import javax.inject.Inject
 import org.gradle.api.GradleException
@@ -92,6 +94,8 @@ class PalantirDockerPlugin implements Plugin<Project> {
         Zip dockerfileZip = project.tasks.create('dockerfileZip', Zip, {
             group = 'Docker'
             description = 'Bundles the configured Dockerfile in a zip file'
+            archiveBaseName.convention(project.name)
+            destinationDirectory.convention(project.layout.buildDirectory.dir("distributions"))
         })
 
         PublishArtifact dockerArtifact = new ArchivePublishArtifact(dockerfileZip)

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -94,6 +94,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
         Zip dockerfileZip = project.tasks.create('dockerfileZip', Zip, {
             group = 'Docker'
             description = 'Bundles the configured Dockerfile in a zip file'
+
             archiveBaseName.convention(project.name)
             destinationDirectory.convention(project.layout.buildDirectory.dir("distributions"))
         })
@@ -176,6 +177,7 @@ class PalantirDockerPlugin implements Plugin<Project> {
 
             dockerfileZip.with {
                 from(ext.resolvedDockerfile)
+                archiveVersion.convention("${project.version}")
             }
         }
     }

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -721,12 +721,11 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         file("build/docker/myDir/bar").exists()
     }
-    def 'dockerfileZip work without the distribution plugin'() {
+    def 'dockerfileZip works without the distribution plugin'() {
         given:
         def dockerfilePath = 'scr/docker/Dockerfile'
         buildFile << """
         plugins {
-            //id 'distribution'
             id 'com.palantir.docker'
         }
         docker {

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -722,11 +722,12 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         file("build/docker/myDir/bar").exists()
     }
 
-    def 'dockerfileZip works without the distribution plugin'() {
+    def 'dockerfileZip works with default settings'() {
         given:
         def dockerfilePath = 'scr/docker/Dockerfile'
         buildFile << """
         plugins {
+            $distPlugin
             id 'com.palantir.docker'
         }
         docker {
@@ -743,17 +744,22 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
         then:
         buildResult.task(":dockerfileZip").outcome == TaskOutcome.SUCCESS
-        file("build/distributions/${projectDir.name}.zip").exists()
+        file("build/distributions/${projectDir.name}-unspecified.zip").exists()
+
+        where:
+        distPlugin << ["id 'distribution'", '']
     }
 
-    def 'dockerfileZip works with the distribution plugin'() {
+    def 'dockerfileZip works with the project version'() {
         given:
         def dockerfilePath = 'scr/docker/Dockerfile'
         buildFile << """
         plugins {
             id 'com.palantir.docker'
-            id 'distribution'
+            $distPlugin
         }
+
+        project.version '0.42'
         docker {
             name 'whatever'
             dockerfile file('$dockerfilePath')
@@ -768,7 +774,10 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
 
         then:
         buildResult.task(":dockerfileZip").outcome == TaskOutcome.SUCCESS
-        file("build/distributions/${projectDir.name}.zip").exists()
+        file("build/distributions/${projectDir.name}-0.42.zip").exists()
+
+        where:
+        distPlugin << ["id 'distribution'", '']
     }
 
     def 'can set output for dockerfileZip task'() {
@@ -777,7 +786,9 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildFile << """
         plugins {
             id 'com.palantir.docker'
+            $distPlugin
         }
+
         docker {
             name 'whatever'
             dockerfile file('$dockerfilePath')
@@ -798,5 +809,8 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         then:
         buildResult.task(":dockerfileZip").outcome == TaskOutcome.SUCCESS
         file('build/dist1/test-distribution.zip').exists()
+
+        where:
+        distPlugin << ["id 'distribution'", '']
     }
 }

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -721,4 +721,27 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.task(':dockerPrepare').outcome == TaskOutcome.SUCCESS
         file("build/docker/myDir/bar").exists()
     }
+    def 'dockerfileZip work without the distribution plugin'() {
+        given:
+        def dockerfilePath = 'scr/docker/Dockerfile'
+        buildFile << """
+        plugins {
+            //id 'distribution'
+            id 'com.palantir.docker'
+        }
+        docker {
+            name 'whatever'
+            dockerfile file('$dockerfilePath')
+        }   
+        """.stripIndent()
+
+        file('scr/docker/Dockerfile') << """
+        FROM scratch
+        """.stripIndent()
+        when:
+        BuildResult buildResult = with('dockerfileZip').build()
+
+        then:
+        buildResult.task(":dockerfileZip").outcome == TaskOutcome.SUCCESS
+    }
 }


### PR DESCRIPTION
## Before this PR
If we don't apply the distribution plugin, dockerfileZip breaks a build.

## After this PR
dockerfileZip don't break builds.


