### PR TITLE
Docker push pushes all tags

### DIFF
--- a/changelog/@unreleased/pr-506.v2.yml
+++ b/changelog/@unreleased/pr-506.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: The dockerPush task is now an alias for the dockerTagsPush task and
+    will push all available tags per default.
+  links:
+  - https://github.com/palantir/gradle-docker/pull/506

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -78,15 +78,15 @@ class PalantirDockerPlugin implements Plugin<Project> {
             dependsOn exec
         })
 
-        Exec push = project.tasks.create('dockerPush', Exec, {
-            group = 'Docker'
-            description = 'Pushes named Docker image to configured Docker Hub.'
-            dependsOn tag
-        })
-
         Task pushAllTags = project.tasks.create('dockerTagsPush', {
             group = 'Docker'
             description = 'Pushes all tagged Docker images to configured Docker Hub.'
+        })
+
+        project.tasks.create('dockerPush', {
+            group = 'Docker'
+            description = 'Pushes named Docker image to configured Docker Hub.'
+            dependsOn pushAllTags
         })
 
         Zip dockerfileZip = project.tasks.create('dockerfileZip', Zip, {
@@ -163,11 +163,6 @@ class PalantirDockerPlugin implements Plugin<Project> {
                     dependsOn tagSubTask
                 })
                 pushAllTags.dependsOn pushSubTask
-            }
-
-            push.with {
-                workingDir dockerDir
-                commandLine 'docker', 'push', "${-> ext.name}"
             }
 
             dockerfileZip.with {


### PR DESCRIPTION
## Before this PR

The previous behavior of `docker push` was to push all tags of a given image. This changed recently where `docker push` will just push the `latest` tag per default (see: https://github.com/moby/moby/pull/40302, https://github.com/docker/cli/pull/2220).

A bunch of users relied on having the `./gradlew dockerPush` task as a default task for pushing all tags and are now no longer publishing all tags.

## After this PR

The `dockerPush` task is now an alias for the `dockerTagsPush` task and will push all available tags per default.

==COMMIT_MSG==
Docker push pushes all tags
==COMMIT_MSG==

## Possible downsides?

Maybe we should instead migrate all users that rely on this feature to use `dockerTagsPush` instead of `dockerPush` and keep the current behavior?
