### PR TITLE
Use project version as default tag

### DIFF
--- a/changelog/@unreleased/pr-513.v2.yml
+++ b/changelog/@unreleased/pr-513.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use project version as default tag
+  links:
+  - https://github.com/palantir/gradle-docker/pull/513

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -35,7 +35,7 @@ class DockerExtension {
     private String dockerComposeTemplate = 'docker-compose.yml.template'
     private String dockerComposeFile = 'docker-compose.yml'
     private Set<Task> dependencies = ImmutableSet.of()
-    private Set<String> tags = ImmutableSet.of();
+    private Set<String> tags = ImmutableSet.of()
     private Map<String, String> namedTags = new HashMap<>()
     private Map<String, String> labels = ImmutableMap.of()
     private Map<String, String> buildArgs = ImmutableMap.of()

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
+import org.gradle.api.provider.SetProperty
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
@@ -34,13 +35,13 @@ class DockerExtension {
     private String dockerComposeTemplate = 'docker-compose.yml.template'
     private String dockerComposeFile = 'docker-compose.yml'
     private Set<Task> dependencies = ImmutableSet.of()
-    private Set<String> tags = ImmutableSet.of()
     private Map<String, String> namedTags = new HashMap<>()
     private Map<String, String> labels = ImmutableMap.of()
     private Map<String, String> buildArgs = ImmutableMap.of()
     private boolean pull = false
     private boolean noCache = false
     private String network = null
+    private SetProperty<String> tags
 
     private File resolvedDockerfile = null
     private File resolvedDockerComposeTemplate = null
@@ -52,6 +53,8 @@ class DockerExtension {
     public DockerExtension(Project project) {
         this.project = project
         this.copySpec = project.copySpec()
+        this.tags = project.getObjects().setProperty(String.class)
+        tags.convention(project.provider({ImmutableSet.<String> of(project.getVersion().toString())}))
     }
 
     public void setName(String name) {
@@ -70,7 +73,7 @@ class DockerExtension {
     public void setDockerComposeTemplate(String dockerComposeTemplate) {
         this.dockerComposeTemplate = dockerComposeTemplate
         Preconditions.checkArgument(project.file(dockerComposeTemplate).exists(),
-            "Could not find specified template file: %s", project.file(dockerComposeTemplate))
+                "Could not find specified template file: %s", project.file(dockerComposeTemplate))
     }
 
     public void setDockerComposeFile(String dockerComposeFile) {
@@ -90,12 +93,12 @@ class DockerExtension {
     }
 
     public Set<String> getTags() {
-        return tags
+        return tags.get()
     }
 
     @Deprecated
     public void tags(String... args) {
-        this.tags = ImmutableSet.copyOf(args)
+        this.tags.set(ImmutableSet.copyOf(args))
     }
 
     public Map<String, String> getNamedTags() {

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -19,10 +19,10 @@ import com.google.common.base.Preconditions
 import com.google.common.base.Strings
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.ImmutableSet
+import com.google.common.collect.Sets
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
-import org.gradle.api.provider.SetProperty
 import org.gradle.internal.logging.text.StyledTextOutput
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 
@@ -35,13 +35,13 @@ class DockerExtension {
     private String dockerComposeTemplate = 'docker-compose.yml.template'
     private String dockerComposeFile = 'docker-compose.yml'
     private Set<Task> dependencies = ImmutableSet.of()
+    private Set<String> tags = ImmutableSet.of();
     private Map<String, String> namedTags = new HashMap<>()
     private Map<String, String> labels = ImmutableMap.of()
     private Map<String, String> buildArgs = ImmutableMap.of()
     private boolean pull = false
     private boolean noCache = false
     private String network = null
-    private SetProperty<String> tags
 
     private File resolvedDockerfile = null
     private File resolvedDockerComposeTemplate = null
@@ -53,8 +53,6 @@ class DockerExtension {
     public DockerExtension(Project project) {
         this.project = project
         this.copySpec = project.copySpec()
-        this.tags = project.getObjects().setProperty(String.class)
-        tags.convention(project.provider({ImmutableSet.<String> of(project.getVersion().toString())}))
     }
 
     public void setName(String name) {
@@ -93,12 +91,12 @@ class DockerExtension {
     }
 
     public Set<String> getTags() {
-        return tags.get()
+        return Sets.union(this.tags, ImmutableSet.of(project.getVersion().toString()))
     }
 
     @Deprecated
     public void tags(String... args) {
-        this.tags.set(ImmutableSet.copyOf(args))
+        this.tags = ImmutableSet.copyOf(args)
     }
 
     public Map<String, String> getNamedTags() {


### PR DESCRIPTION
## Before this PR
With https://github.com/palantir/gradle-docker/pull/506, we added a regression that not all docker images would be pushed if no tags were specified explicitly.

This is because the tasks `dockerTagsPush` and `dockerPush` are just marker tasks that run the respective tag and push tasks for all tags. However, when no tags are specified, no sub-tasks will be created and run as the below closure is skipped:

https://github.com/palantir/gradle-docker/blob/db4cfe13b99f703666247c0e17268318c58c58f9/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy#L148

## After this PR
To work-around this, we add the project version as a default tag, if not other tags are specified. This will per-default tag and push an image with the current project version.

==COMMIT_MSG==
Use project version as default tag
==COMMIT_MSG==