### PR TITLE
fix: handle a blank version

### DIFF
--- a/changelog/@unreleased/pr-560-v1.yaml
+++ b/changelog/@unreleased/pr-560-v1.yaml
@@ -1,0 +1,5 @@
+type: fix
+improvement:
+  description: Allow for version to be blank
+  links:
+    - https://github.com/palantir/gradle-docker/pull/560

--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -95,7 +95,8 @@ class DockerExtension {
     }
 
     public Set<String> getTags() {
-        return Sets.union(this.tags, ImmutableSet.of(project.getVersion().toString()))
+        final String version = project.getVersion().toString()
+        return Sets.union(this.tags, ImmutableSet.of(version.isEmpty() ? Project.DEFAULT_VERSION : version))
     }
 
     @Deprecated

--- a/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
+++ b/src/test/groovy/com/palantir/gradle/docker/PalantirDockerPluginTests.groovy
@@ -298,6 +298,32 @@ class PalantirDockerPluginTests extends AbstractPluginTest {
         buildResult.output.contains('dockerPushWithTaskNameByTag')
     }
 
+    def 'handle version is blank'() {
+        given:
+        String id = 'id5'
+        file('Dockerfile') << """
+            FROM alpine:3.2
+            MAINTAINER ${id}
+        """.stripIndent()
+        buildFile << """
+            plugins {
+                id 'com.palantir.docker'
+            }
+
+            version = ""
+            docker {
+                name '${id}'
+                tag 'withTaskNameByTag', '${id}:new-latest'
+            }
+        """.stripIndent()
+
+        when:
+        BuildResult buildResult = with('tasks').build()
+
+        then:
+        buildResult.output.contains('dockerTagUnspecified')
+    }
+
     def 'does not throw if name is configured after evaluation phase'() {
         given:
         String id = 'id6'


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Handle when the gradle config includes a blank version. Currently this fails with

```
> begin 0, end 1, length 0
```

## After this PR

Following should not raise an exception 

```groovy
plugins {
    id 'com.palantir.docker'
}

version = ""
docker {
    name 'foo'
    tag 'withTaskNameByTag', 'foo:new-latest'
}
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Blank `version` will now default to `unspecified`

