### PR TITLE
Add docker gradle plugin defunct declaration

### DIFF
--- a/changelog/@unreleased/pr-573.v2.yml
+++ b/changelog/@unreleased/pr-573.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `docker` plugin is declared as defunct.
+  links:
+  - https://github.com/palantir/gradle-docker/pull/573

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Disclaimer: This Repo is now Defunct
 -------------
 
 - This repo is on life support only - although we will keep it working, no new features are accepted;
-- It is now barely used internally at Palantir - Our internal gradle tooling should be used instead.
+- It is no longer used internally at Palantir.
 
 Docker Plugin
 -------------

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,11 @@ This repository provides three Gradle plugins for working with Docker containers
 - `com.palantir.docker-run`: adds tasks for starting, stopping, statusing and cleaning
   up a named container based on a specified image
 
-Docker Plugin
+~Docker Plugin~ - **Defunct**
 -------------
+
+**The `docker` gradle plugin is now defunct and should no longer be used.**
+
 Apply the plugin using standard gradle convention:
 
 ````gradle

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Docker Gradle Plugin
 [![Gradle Plugins Release](https://img.shields.io/github/release/palantir/gradle-docker.svg)](https://plugins.gradle.org/plugin/com.palantir.docker)
 
 This repository provides three Gradle plugins for working with Docker containers:
-- `com.palantir.docker`: add basic tasks for building and pushing
+- `com.palantir.docker` **(DEFUNCT)**: add basic tasks for building and pushing
   docker images based on a simple configuration block that specifies the container
   name, the Dockerfile, task dependencies, and any additional file resources
   required for the Docker build.
@@ -18,10 +18,8 @@ This repository provides three Gradle plugins for working with Docker containers
 - `com.palantir.docker-run`: adds tasks for starting, stopping, statusing and cleaning
   up a named container based on a specified image
 
-~Docker Plugin~ - **Defunct**
+~Docker Plugin~ - **Defunct: The `docker` gradle plugin is now defunct and should no longer be used.**
 -------------
-
-**The `docker` gradle plugin is now defunct and should no longer be used.**
 
 Apply the plugin using standard gradle convention:
 

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,15 @@ Docker Gradle Plugin
 [![Build Status](https://circleci.com/gh/palantir/gradle-docker.svg?style=shield)](https://circleci.com/gh/palantir/gradle-docker)
 [![Gradle Plugins Release](https://img.shields.io/github/release/palantir/gradle-docker.svg)](https://plugins.gradle.org/plugin/com.palantir.docker)
 
+Disclaimer: This Repo is now Defunct
+-------------
+
+- This repo is on life support only - although we will keep it working, no new features are accepted;
+- It is now barely used internally at Palantir - Our internal gradle tooling should be used instead.
+
+Docker Plugin
+-------------
+
 This repository provides three Gradle plugins for working with Docker containers:
 - `com.palantir.docker`: add basic tasks for building and pushing
   docker images based on a simple configuration block that specifies the container
@@ -18,8 +27,6 @@ This repository provides three Gradle plugins for working with Docker containers
 - `com.palantir.docker-run`: adds tasks for starting, stopping, statusing and cleaning
   up a named container based on a specified image
 
-Docker Plugin
--------------
 Apply the plugin using standard gradle convention:
 
 ````gradle

--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,8 @@ This repository provides three Gradle plugins for working with Docker containers
 - `com.palantir.docker-run`: adds tasks for starting, stopping, statusing and cleaning
   up a named container based on a specified image
 
-~Docker Plugin~ - **Defunct**
+Docker Plugin
 -------------
-
-**The `docker` gradle plugin is now defunct and should no longer be used.**
-
 Apply the plugin using standard gradle convention:
 
 ````gradle

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Docker Gradle Plugin
 [![Gradle Plugins Release](https://img.shields.io/github/release/palantir/gradle-docker.svg)](https://plugins.gradle.org/plugin/com.palantir.docker)
 
 This repository provides three Gradle plugins for working with Docker containers:
-- `com.palantir.docker` **(DEFUNCT)**: add basic tasks for building and pushing
+- `com.palantir.docker`: add basic tasks for building and pushing
   docker images based on a simple configuration block that specifies the container
   name, the Dockerfile, task dependencies, and any additional file resources
   required for the Docker build.
@@ -18,8 +18,10 @@ This repository provides three Gradle plugins for working with Docker containers
 - `com.palantir.docker-run`: adds tasks for starting, stopping, statusing and cleaning
   up a named container based on a specified image
 
-~Docker Plugin~ - **Defunct: The `docker` gradle plugin is now defunct and should no longer be used.**
+~Docker Plugin~ - **Defunct**
 -------------
+
+**The `docker` gradle plugin is now defunct and should no longer be used.**
 
 Apply the plugin using standard gradle convention:
 


### PR DESCRIPTION
## Before this PR

There's no info on the repo stating that the `docker` plugin is no longer supported and should no longer be used.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
The `docker` plugin is declared as defunct.
==COMMIT_MSG==

## Possible downsides?

