### PR TITLE
Add platform flag for docker build without a reliance on docker buildx

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,8 @@ build/
 - `noCache` (optional) a boolean argument which defines whether Docker build should add the option --no-cache,
     so that it rebuilds the whole image from scratch; defaults to `false`
 - `buildx` (optional) a boolean argument which defines whether Docker build should use buildx for cross platform builds; defaults to `false`
-- `platform` (optional) a list of strings argument which defines which platforms buildx should target; defaults to empty
+- `platform` (for buildx optional) a list of strings argument which defines which platforms buildx should target; defaults to empty
+- `platform` (for build optional) string which defines which platform build should target; defaults to empty
 - `builder` (optional) a string argument which defines which builder buildx should use; defaults to `null`
 - `load` (optional) a boolean argument which defines whether Docker buildx builder should add --load flag,
   loading the image into the local repository; defaults to `false`

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -192,6 +192,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
             }
         } else {
             buildCommandLine.add 'build'
+            if (!ext.platform.isEmpty()) {
+                buildCommandLine.addAll('--platform', ext.platform)
+            }
         }
         if (ext.noCache) {
             buildCommandLine.add '--no-cache'


### PR DESCRIPTION
## Before this PR

Platform flag is only supported for docker buildx and not docker.

Example of the docker command we would like to run:

docker build --platform linux/arm64 -t example .

## After this PR
The platform flag will be supported such as this to build for a single platform:

```
docker {
    name "example:$version"
    platform "arm64"
```

## Possible downsides?

On upgrade from one version to a version with this commit in it while having the platform flag in a non working state would cause gradle to throw errors rather than silently ignore.