### PR TITLE
Support target parameter for multi-stage Docker builds

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -47,6 +47,7 @@ class DockerExtension {
     private boolean load = false
     private boolean push = false
     private String builder = null
+    private String target = null
 
     private File resolvedDockerfile = null
     private File resolvedDockerComposeTemplate = null
@@ -219,5 +220,13 @@ class DockerExtension {
 
     public void builder(String builder) {
         this.builder = builder
+    }
+
+    String getTarget() {
+        return target
+    }
+
+    void setTarget(String target) {
+        this.target = target
     }
 }

--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -217,6 +217,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
         if (ext.pull) {
             buildCommandLine.add '--pull'
         }
+        if (ext.target) {
+            buildCommandLine.add "--target=${ext.target}"
+        }
         buildCommandLine.addAll(['-t', "${-> ext.name}", '.'])
         return buildCommandLine
     }


### PR DESCRIPTION
## Before this PR
The plugin doesn't support the "target" parameter for "docker build"

## After this PR
Added an optional "target" parameter that takes a single String specifying the target parameter for docker build

## Possible downsides?
Don't think are any
