### PR TITLE
do not use gradle internal ArchivePublishArtifact

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.PublishArtifact
-import org.gradle.api.internal.artifacts.publish.ArchivePublishArtifact
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
@@ -94,9 +93,8 @@ class PalantirDockerPlugin implements Plugin<Project> {
             description = 'Bundles the configured Dockerfile in a zip file'
         })
 
-        PublishArtifact dockerArtifact = new ArchivePublishArtifact(dockerfileZip)
         Configuration dockerConfiguration = project.getConfigurations().getByName('docker')
-        dockerConfiguration.getArtifacts().add(dockerArtifact)
+        PublishArtifact dockerArtifact = project.artifacts.add('docker', dockerfileZip)
         project.getComponents().add(new DockerComponent(dockerArtifact, dockerConfiguration.getAllDependencies(),
                 objectFactory, attributesFactory))
 


### PR DESCRIPTION
## Before this PR
Plugin is not compatible with gradle version upper 8.0 #618 

## After this PR
Gradle plugin can't use internal class `ArchivePublishArtifact` anymore upper 8.0. https://github.com/JetBrains/gradle-intellij-plugin/issues/1272
Do not use internal class `ArchivePublishArtifact` directly, instead make artifact with recommended API.
