### PR TITLE
Fix typo in the load flag getter/setters

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/DockerExtension.groovy
@@ -182,11 +182,11 @@ class DockerExtension {
     }
 
     public boolean getLoad() {
-        return pull
+        return load
     }
 
-    public void load(boolean pull) {
-        this.pull = pull
+    public void load(boolean load) {
+        this.load = load
     }
 
     public boolean getPush() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

It seems like there was a typo in the getter/setter for the `load` variable. I noticed this when I was trying to set up buildx multi-architecture publishing and getting errors about having both `load` and `push` set, even though I was explicitly setting `load` to `false`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix typo in the load flag getter/setters
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

