### PR TITLE
Update PalantirDockerPlugin.groovy added sbom parameter

### DIFF
--- a/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
+++ b/src/main/groovy/com/palantir/gradle/docker/PalantirDockerPlugin.groovy
@@ -176,6 +176,9 @@ class PalantirDockerPlugin implements Plugin<Project> {
             if (!ext.platform.isEmpty()) {
                 buildCommandLine.addAll('--platform', String.join(',', ext.platform))
             }
+	    if (ext.sbom) {
+		buildCommandLine.add '--sbom=true'
+	    }
             if (ext.load) {
                 buildCommandLine.add '--load'
             }


### PR DESCRIPTION
Added the `--sbom` parameter to the command line, enabling the generation of a Software Bill of Materials (SBOM) during the build process. https://github.com/palantir/gradle-docker/issues/761

## Before this PR
Lack of ability to build an image from the SBOM

## After this PR
The ability to create an image from an SBOM

## Possible downsides?
don;t see any

